### PR TITLE
fix: correct the creation of esbuild plugin filter regex

### DIFF
--- a/packages/esbuild-plugin-transform/lib/index.js
+++ b/packages/esbuild-plugin-transform/lib/index.js
@@ -5,6 +5,7 @@ import { createPipeline, finalize } from '@chialab/estransform';
 import { escapeRegexBody } from '@chialab/node-resolve';
 
 export const SCRIPT_LOADERS = ['tsx', 'ts', 'jsx', 'js'];
+const DEFAULT_TSX_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
 
 /**
  * @typedef {Map<string, import('@chialab/estransform').Pipeline>} Store
@@ -33,8 +34,8 @@ export function createFilter(build) {
 
     const { loader: loaders = {} } = build.initialOptions;
     const keys = Object.keys(loaders);
-    const tsxExtensions = keys.filter((key) => SCRIPT_LOADERS.includes(loaders[key]));
-    return new RegExp(`\\.(${tsxExtensions.map((ext) => ext.replace('.', '')).join('|')})$`);
+    const tsxExtensions = keys.filter((key) => SCRIPT_LOADERS.includes(loaders[key]) && !DEFAULT_TSX_EXTENSIONS.includes(key));
+    return new RegExp(`\\.(${[...tsxExtensions, ...DEFAULT_TSX_EXTENSIONS].map((ext) => ext.replace('.', '')).join('|')})$`);
 }
 
 /**


### PR DESCRIPTION
When `esbuild.initialOptions.loader` is not set, the filter
regex will be `/\.()$/` which is inappropriate. It should
support the file extension of the default script loaders
defined by `SCRIPT_LOADERS`

Example:
```typescript
await build({
  entryPoints: [
    "./node_modules/react/cjs/react.development.js",
  ],
  bundle: true,
  outfile: "out.js",
  format: "esm",
  /* loader: {
    ".js": "js",
  }, */ <--- comment out
  plugins: [commonjsPlugin()],
})
```

`commonjsPlugin` won't work in this case