### PR TITLE
Warn when using module resolution with meta uris

### DIFF
--- a/packages/esbuild-plugin-html/test/test.spec.js
+++ b/packages/esbuild-plugin-html/test/test.spec.js
@@ -402,7 +402,7 @@ body {
             plugins: [
                 virtualPlugin([
                     {
-                        path: 'index.html',
+                        path: new URL('./index.html', import.meta.url).pathname,
                         contents: `<!DOCTYPE html>
 <html lang="en">
 <head>

--- a/packages/esbuild-plugin-meta-url/lib/index.js
+++ b/packages/esbuild-plugin-meta-url/lib/index.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import { isUrl, hasSearchParam } from '@chialab/node-resolve';
-import { parse, walk, getIdentifierValue, getBlock, TokenType } from '@chialab/estransform';
+import { parse, walk, getIdentifierValue, getBlock, getLocation, TokenType } from '@chialab/estransform';
 import { useRna } from '@chialab/esbuild-rna';
 
 /**
@@ -141,6 +141,11 @@ export default function({ emit = true } = {}) {
 
                 const { helpers, processor } = await parse(code, args.path);
 
+                /**
+                 * @type {import('esbuild').Message[]}
+                 */
+                const warnings = [];
+
                 await walk(processor, () => {
                     const value = getMetaUrl(processor);
                     if (typeof value !== 'string' || isUrl(value)) {
@@ -158,24 +163,55 @@ export default function({ emit = true } = {}) {
                     }
 
                     promises.push(Promise.resolve().then(async () => {
-                        const { path: resolvedPath } = await build.resolve(value.split('?')[0], {
-                            kind: 'dynamic-import',
-                            importer: args.path,
-                            namespace: 'file',
-                            resolveDir: path.dirname(args.path),
-                            pluginData: null,
-                        });
-
-                        if (!resolvedPath) {
-                            return;
+                        const requestName = value.split('?')[0];
+                        const candidates = [];
+                        if (requestName.startsWith('./') || requestName.startsWith('../')) {
+                            candidates.push(requestName);
+                        } else {
+                            candidates.push(requestName, `./${requestName}`);
                         }
 
-                        const entryLoader = buildLoaders[path.extname(resolvedPath)] || 'file';
-                        const entryPoint = emit ?
-                            (entryLoader !== 'file' && entryLoader !== 'json' ? await emitChunk({ entryPoint: resolvedPath }) : await emitFile(resolvedPath)).path :
-                            `./${path.relative(path.dirname(args.path), resolvedPath)}`;
+                        while (candidates.length) {
+                            const pathName = /** @type {string} */ (candidates.shift());
+                            const { path: resolvedPath } = await build.resolve(pathName, {
+                                kind: 'dynamic-import',
+                                importer: args.path,
+                                namespace: 'file',
+                                resolveDir: path.dirname(args.path),
+                                pluginData: null,
+                            });
 
-                        helpers.overwrite(startToken.start, endToken.end, `new URL('${entryPoint}', ${baseUrl})`);
+                            if (!resolvedPath) {
+                                continue;
+                            }
+
+                            if (!pathName.startsWith('./') && !pathName.startsWith('../')) {
+                                const location = getLocation(code, startToken.start);
+                                warnings.push({
+                                    pluginName: 'meta-url',
+                                    text: `Resolving '${pathName}' as module is not a standard behavior and may be removed in a future relase of the plugin.`,
+                                    location: {
+                                        file: args.path,
+                                        namespace: args.namespace,
+                                        ...location,
+                                        length: endToken.end - startToken.start,
+                                        lineText: code.split('\n')[location.line - 1],
+                                        suggestion: 'Externalize module import using a JS proxy file.',
+                                    },
+                                    notes: [],
+                                    detail: '',
+                                });
+                            }
+
+                            const entryLoader = buildLoaders[path.extname(resolvedPath)] || 'file';
+                            const entryPoint = emit ?
+                                (entryLoader !== 'file' && entryLoader !== 'json' ? await emitChunk({ entryPoint: resolvedPath }) : await emitFile(resolvedPath)).path :
+                                `./${path.relative(path.dirname(args.path), resolvedPath)}`;
+
+                            helpers.overwrite(startToken.start, endToken.end, `new URL('${entryPoint}', ${baseUrl})`);
+
+                            break;
+                        }
                     }));
                 });
 
@@ -189,10 +225,13 @@ export default function({ emit = true } = {}) {
                     helpers.prepend('var __currentScriptUrl__ = document.currentScript && document.currentScript.src || document.baseURI;\n');
                 }
 
-                return helpers.generate({
-                    sourcemap: !!sourcemap,
-                    sourcesContent,
-                });
+                return {
+                    ...helpers.generate({
+                        sourcemap: !!sourcemap,
+                        sourcesContent,
+                    }),
+                    warnings,
+                };
             });
         },
     };

--- a/packages/esbuild-plugin-meta-url/lib/index.js
+++ b/packages/esbuild-plugin-meta-url/lib/index.js
@@ -168,7 +168,7 @@ export default function({ emit = true } = {}) {
                         if (requestName.startsWith('./') || requestName.startsWith('../')) {
                             candidates.push(requestName);
                         } else {
-                            candidates.push(requestName, `./${requestName}`);
+                            candidates.push(`./${requestName}`, requestName);
                         }
 
                         while (candidates.length) {

--- a/packages/esbuild-plugin-virtual/lib/index.js
+++ b/packages/esbuild-plugin-virtual/lib/index.js
@@ -41,8 +41,8 @@ export default function virtual(entries) {
 
             entries.forEach((entry) => {
                 const resolveDir = entry.resolveDir || rootDir;
-                const virtualFilePath = path.join(resolveDir, entry.path);
-                const filter = new RegExp(escapeRegexBody(entry.path));
+                const virtualFilePath = path.isAbsolute(entry.path) ? entry.path : path.join(resolveDir, entry.path);
+                const filter = new RegExp(`^${escapeRegexBody(entry.path)}$`);
                 const entryFilter = new RegExp(escapeRegexBody(virtualFilePath));
 
                 build.onResolve({ filter }, () => ({

--- a/packages/estransform/lib/helpers.js
+++ b/packages/estransform/lib/helpers.js
@@ -74,6 +74,35 @@ export function getIdentifierValue(processor, id) {
 }
 
 /**
+ * Get token location.
+ * @param {string} code Source code.
+ * @param {number} index Token index.
+ * @return A location.
+ */
+export function getLocation(code, index) {
+    let it = 0;
+    let line = 1;
+    let column = -1;
+
+    if (index > code.length) {
+        throw new Error('Token index exceeds source code length');
+    }
+
+    while (it <= index) {
+        const char = code[it];
+        if (char === '\n') {
+            line++;
+            column = -1;
+        } else {
+            column++;
+        }
+        it++;
+    }
+
+    return { line, column };
+}
+
+/**
  * @param {import('./parser.js').TokenProcessor} processor
  * @param {TokenType} [openingToken]
  * @param {TokenType} [closingToken]


### PR DESCRIPTION
As stated in #47, standard `URL` resolution conflicts with esbuild resolution when using non-explicit relative paths. With this PR we are going to prefer local imports, fallbacking (with a warning) to NPM module when local file is not available.