### PR TITLE
Split HTML builds

### DIFF
--- a/.changeset/twenty-chairs-shake.md
+++ b/.changeset/twenty-chairs-shake.md
@@ -1,0 +1,45 @@
+---
+"@chialab/esbuild-plugin-html": minor
+"@chialab/esbuild-plugin-meta-url": minor
+"@chialab/esbuild-plugin-require-resolve": minor
+"@chialab/esbuild-plugin-virtual": minor
+"@chialab/esbuild-plugin-worker": minor
+"@chialab/esbuild-rna": minor
+"@chialab/cjs-to-esm": minor
+"@chialab/es-dev-server": minor
+"@chialab/es-test-runner": minor
+"@chialab/esbuild-plugin-alias": minor
+"@chialab/esbuild-plugin-any-file": minor
+"@chialab/esbuild-plugin-babel": minor
+"@chialab/esbuild-plugin-commonjs": minor
+"@chialab/esbuild-plugin-css-import": minor
+"@chialab/esbuild-plugin-define-this": minor
+"@chialab/esbuild-plugin-env": minor
+"@chialab/esbuild-plugin-external": minor
+"@chialab/esbuild-plugin-jsx-import": minor
+"@chialab/esbuild-plugin-postcss": minor
+"@chialab/esbuild-plugin-unwebpack": minor
+"@chialab/estransform": minor
+"@chialab/node-resolve": minor
+"@chialab/postcss-dart-sass": minor
+"@chialab/postcss-preset-chialab": minor
+"@chialab/postcss-url-rebase": minor
+"@chialab/rna": minor
+"@chialab/rna-apidoc": minor
+"@chialab/rna-browser-test-runner": minor
+"@chialab/rna-bundler": minor
+"@chialab/rna-config-loader": minor
+"@chialab/rna-dev-server": minor
+"@chialab/rna-logger": minor
+"@chialab/rna-node-test-runner": minor
+"@chialab/rna-saucelabs-test-runner": minor
+"@chialab/rna-storybook": minor
+"@chialab/wds-plugin-hmr-css": minor
+"@chialab/wds-plugin-legacy": minor
+"@chialab/wds-plugin-node-resolve": minor
+"@chialab/wds-plugin-polyfill": minor
+"@chialab/wds-plugin-rna": minor
+"@chialab/wtr-mocha-reporter": minor
+---
+
+Release 0.16.0

--- a/packages/esbuild-plugin-html/lib/collectAssets.js
+++ b/packages/esbuild-plugin-html/lib/collectAssets.js
@@ -1,36 +1,46 @@
 import { isRelativeUrl } from '@chialab/node-resolve';
 
 /**
+ * @param {import('cheerio').CheerioAPI} $ The cheerio selector.
+ * @param {import('cheerio').Cheerio<import('cheerio').Element>} element The DOM element.
+ * @param {string} attribute The element attribute to load.
+ * @param {import('./index.js').BuildOptions} options Build options.
+ * @param {import('./index.js').Helpers} helpers Helpers.
+ * @returns {Promise<import('@chialab/esbuild-rna').OnTransformResult|void>} Plain build.
+ */
+export async function collectAsset($, element, attribute, options, helpers) {
+    const resolvedFile = await helpers.resolve(/** @type {string} */ (element.attr(attribute)));
+    if (!resolvedFile.path) {
+        return;
+    }
+
+    const entryPoint = resolvedFile.path;
+    const file = await helpers.emitFile(entryPoint);
+    element.attr(attribute, file.path);
+
+    return {
+        ...file,
+        watchFiles: [entryPoint],
+    };
+}
+
+/**
  * Collect and bundle each node with a src reference.
  * @type {import('./index').Collector}
  */
-export async function collectAssets($, dom) {
-    return [
+export async function collectAssets($, dom, options, helpers) {
+    const builds = await Promise.all([
         ...dom
             .find('[src]:not(script)')
             .get()
             .filter((element) => isRelativeUrl($(element).attr('src')))
-            .map((element) => /** @type {import('./index.js').CollectResult} */ ({
-                build: {
-                    entryPoint: /** @type {string} */ ($(element).attr('src')),
-                    loader: /** @type {import('esbuild').Loader} */ ('file'),
-                },
-                finisher(files) {
-                    $(element).attr('src', files[0]);
-                },
-            })),
+            .map((element) => collectAsset($, $(element), 'src', options, helpers)),
         ...dom
             .find('link[href]:not([rel="stylesheet"]):not([rel="manifest"]):not([rel*="icon"]):not([rel*="apple-touch-startup-image"]), a[download][href], iframe[href]')
             .get()
             .filter((element) => isRelativeUrl($(element).attr('href')))
-            .map((element) => /** @type {import('./index.js').CollectResult} */ ({
-                build: {
-                    entryPoint: /** @type {string} */ ($(element).attr('href')),
-                    loader: /** @type {import('esbuild').Loader} */ ('file'),
-                },
-                finisher(files) {
-                    $(element).attr('href', files[0]);
-                },
-            })),
-    ];
+            .map((element) => collectAsset($, $(element), 'href', options, helpers)),
+    ]);
+
+    return /** @type {import('@chialab/esbuild-rna').OnTransformResult[]} */ (builds.filter((build) => !!build));
 }

--- a/packages/esbuild-plugin-html/lib/collectScripts.js
+++ b/packages/esbuild-plugin-html/lib/collectScripts.js
@@ -34,7 +34,7 @@ async function innerCollect($, dom, elements, target, format, type, attrs = {}, 
     await Promise.all(elements.map(async (element) => {
         const src = $(element).attr('src');
         if (src) {
-            const resolvedFile = await helpers.resolve(`./${src}`);
+            const resolvedFile = await helpers.resolve(src);
             if (!resolvedFile.path) {
                 return;
             }
@@ -77,7 +77,7 @@ async function innerCollect($, dom, elements, target, format, type, attrs = {}, 
         }
 
         const fullOutName = path.join(options.workingDir, outName);
-        const relativeOutName = path.relative(options.outDir, fullOutName);
+        const relativeOutName = path.relative(options.entryDir, fullOutName);
 
         if ($(element).attr('src')) {
             $(element).attr('src', relativeOutName);
@@ -107,7 +107,7 @@ function loadStyle(url) {
 
 ${styleFiles.map((outName) => {
             const fullOutFile = path.join(options.workingDir, outName);
-            const relativeOutFile = path.relative(options.outDir, fullOutFile);
+            const relativeOutFile = path.relative(options.entryDir, fullOutFile);
             return `loadStyle('${relativeOutFile}');`;
         }).join('\n')}
 }());`);

--- a/packages/esbuild-plugin-html/lib/collectScripts.js
+++ b/packages/esbuild-plugin-html/lib/collectScripts.js
@@ -4,60 +4,117 @@ import { isRelativeUrl } from '@chialab/node-resolve';
 /**
  * @param {import('cheerio').CheerioAPI} $ The cheerio selector.
  * @param {import('cheerio').Cheerio<import('cheerio').Document>} dom The DOM element.
- * @param {string} selector Scripts selector.
- * @param {string} sourceDir Build sourceDir.
+ * @param {import('cheerio').Element[]} elements List of nodes.
  * @param {string} target Build target.
  * @param {import('esbuild').Format} format Build format.
  * @param {string} type Script type.
  * @param {{ [key: string]: string }} attrs Script attrs.
+ * @param {import('./index.js').BuildOptions} options Build options.
  * @param {import('./index.js').Helpers} helpers Helpers.
- * @returns {import('./index').CollectResult|void} Plain build.
+ * @returns {Promise<import('@chialab/esbuild-rna').OnTransformResult[]>} Plain build.
  */
-function innerCollect($, dom, selector, sourceDir, target, format, type, attrs = {}, helpers) {
-    const elements = dom.find(selector)
-        .get()
+async function innerCollect($, dom, elements, target, format, type, attrs = {}, options, helpers) {
+    elements = elements
         .filter((element) => !$(element).attr('src') || isRelativeUrl($(element).attr('src')));
 
     if (!elements.length) {
-        return;
+        return [];
     }
 
-    const contents = elements.map((element) => {
-        if ($(element).attr('src')) {
-            return `import './${$(element).attr('src')}';`;
+    /**
+     * @type {Map<import('cheerio').Element, import('@chialab/esbuild-rna').VirtualEntry|string>}
+     */
+    const builds = new Map();
+
+    /**
+     * @type {Map<string, import('cheerio').Element>}
+     */
+    const entrypoints = new Map();
+
+    await Promise.all(elements.map(async (element) => {
+        const src = $(element).attr('src');
+        if (src) {
+            const resolvedFile = await helpers.resolve(`./${src}`);
+            if (!resolvedFile.path) {
+                return;
+            }
+
+            builds.set(element, resolvedFile.path);
+            entrypoints.set(resolvedFile.path, element);
+        } else {
+            const entryPoint = path.join(options.sourceDir, helpers.createEntry('js'));
+            builds.set(element, {
+                path: entryPoint,
+                contents: $(element).html() || '',
+            });
+            entrypoints.set(entryPoint, element);
+        }
+    }));
+
+    const result = await helpers.emitBuild({
+        entryPoints: [...builds.values()],
+        target,
+        format,
+    });
+
+    const outputs = result.metafile.outputs;
+    const styleFiles = Object.keys(outputs).filter((outName) => outName.endsWith('.css'));
+    Object.entries(outputs).forEach(([outName, output]) => {
+        if (outName.endsWith('.map')) {
+            // ignore map files
+            return;
+        }
+        if (!output.entryPoint) {
+            // ignore chunks
+            return;
         }
 
-        return $(element).html();
-    }).join('\n');
+        const entryPoint = path.join(options.workingDir, output.entryPoint);
+        const element = entrypoints.get(entryPoint);
+        if (!element) {
+            // unknown entrypoint
+            return;
+        }
 
-    return {
-        build: {
-            entryPoint: path.join(sourceDir, helpers.createEntry('js')),
-            contents,
-            target,
-            format,
-        },
-        finisher(files) {
-            const [jsOutput, ...outputs] = files;
-            elements.forEach((element) => {
-                $(element).remove();
-            });
-            const script = $(`<script src="${jsOutput}" type="${type}"></script>`);
-            for (const attrName in attrs) {
-                script.attr(attrName, attrs[attrName]);
-            }
-            $('body').append(script);
+        const fullOutName = path.join(options.workingDir, outName);
+        const relativeOutName = path.relative(options.outDir, fullOutName);
 
-            if (attrs.nomodule !== '') {
-                const cssOutputs = outputs.filter((output) => output.endsWith('.css'));
-                if (cssOutputs) {
-                    cssOutputs.forEach((cssOutput) => {
-                        $('head').append(`<link rel="stylesheet" href="${cssOutput}" />`);
-                    });
-                }
-            }
-        },
-    };
+        if ($(element).attr('src')) {
+            $(element).attr('src', relativeOutName);
+            $(element).html('');
+        } else {
+            $(element).html(`import './${relativeOutName}'`);
+        }
+        $(element).removeAttr('type').attr('type', type);
+        for (const attrName in attrs) {
+            $(element).removeAttr(attrName).attr(attrName, attrs[attrName]);
+        }
+    });
+
+    if (styleFiles.length) {
+        const script = $('<script>');
+        for (const attrName in attrs) {
+            $(script).attr(attrName, attrs[attrName]);
+        }
+        $(script).attr('type', type);
+        $(script).html(`(function() {
+function loadStyle(url) {
+    var l = document.createElement('link');
+    l.rel = 'stylesheet';
+    l.href = url;
+    document.head.appendChild(l);
+}
+
+${styleFiles.map((outName) => {
+            const fullOutFile = path.join(options.workingDir, outName);
+            const relativeOutFile = path.relative(options.outDir, fullOutFile);
+            return `loadStyle('${relativeOutFile}');`;
+        }).join('\n')}
+}());`);
+        dom.find('head').append(script);
+    }
+
+    return [result];
 }
 
 /**
@@ -65,39 +122,47 @@ function innerCollect($, dom, selector, sourceDir, target, format, type, attrs =
  * @type {import('./index').Collector}
  */
 export async function collectScripts($, dom, options, helpers) {
-    return /** @type {import('./index').CollectResult[]} */ ([
-        innerCollect(
+    const moduleElements = dom.find('script[src][type="module"], script[type="module"]:not([src])').get();
+    const nomoduleElements = dom.find('script[src]:not([type])[nomodule], script[src][type="text/javascript"][nomodule], script[src][type="application/javascript"][nomodule]').get();
+    const scriptElements = dom.find('script[src]:not([type]):not([nomodule]), script[src][type="text/javascript"]:not([nomodule]), script[src][type="application/javascript"]:not([nomodule])').get();
+
+    const results = [
+        await innerCollect(
             $,
             dom,
-            'script[src]:not([type]):not([nomodule]), script[src][type="text/javascript"]:not([nomodule]), script[src][type="application/javascript"]:not([nomodule])',
-            options.sourceDir,
-            options.target[0],
-            'iife',
-            'application/javascript',
-            {},
-            helpers
-        ),
-        innerCollect(
-            $,
-            dom,
-            'script[src]:not([type])[nomodule], script[src][type="text/javascript"][nomodule], script[src][type="application/javascript"][nomodule]',
-            options.sourceDir,
-            options.target[0],
-            'iife',
-            'application/javascript',
-            { nomodule: '' },
-            helpers
-        ),
-        innerCollect(
-            $,
-            dom,
-            'script[src][type="module"], script[type="module"]:not([src])',
-            options.sourceDir,
+            moduleElements,
             options.target[1],
             'esm',
             'module',
             {},
+            options,
             helpers
         ),
-    ].filter(Boolean));
+    ];
+
+    results.push(await innerCollect(
+        $,
+        dom,
+        nomoduleElements,
+        options.target[0],
+        'iife',
+        'application/javascript',
+        { nomodule: '' },
+        options,
+        helpers
+    ));
+
+    results.push(await innerCollect(
+        $,
+        dom,
+        scriptElements,
+        options.target[0],
+        'iife',
+        'application/javascript',
+        {},
+        options,
+        helpers
+    ));
+
+    return results.flat();
 }

--- a/packages/esbuild-plugin-html/lib/collectStyles.js
+++ b/packages/esbuild-plugin-html/lib/collectStyles.js
@@ -28,7 +28,7 @@ export async function collectStyles($, dom, options, helpers) {
     await Promise.all(elements.map(async (element) => {
         const href = $(element).attr('href');
         if (href) {
-            const resolvedFile = await helpers.resolve(`./${href}`);
+            const resolvedFile = await helpers.resolve(href);
             if (!resolvedFile.path) {
                 return;
             }
@@ -70,7 +70,7 @@ export async function collectStyles($, dom, options, helpers) {
         }
 
         const fullOutName = path.join(options.workingDir, outName);
-        const relativeOutName = path.relative(options.outDir, fullOutName);
+        const relativeOutName = path.relative(options.entryDir, fullOutName);
 
         if ($(element).is('link')) {
             $(element).attr('href', relativeOutName);

--- a/packages/esbuild-plugin-html/lib/index.js
+++ b/packages/esbuild-plugin-html/lib/index.js
@@ -26,6 +26,7 @@ const loadHtml = /** @type {typeof cheerio.load} */ (cheerio.load || cheerio.def
  * @typedef {Object} BuildOptions
  * @property {string} sourceDir
  * @property {string} outDir
+ * @property {string} entryDir
  * @property {string} workingDir
  * @property {string[]} target
  */
@@ -170,7 +171,7 @@ export default function({
                 /**
                  * @param {string} file
                  */
-                const resolveFile = (file) => build.resolve(file.startsWith('./') || file.startsWith('../') ? file : `./${file}`, {
+                const resolveFile = (file) => build.resolve(path.resolve(path.dirname(args.path), file), {
                     kind: 'dynamic-import',
                     importer: args.path,
                     resolveDir: path.dirname(args.path),
@@ -194,6 +195,7 @@ export default function({
                     sourceDir: path.dirname(args.path),
                     workingDir,
                     outDir: path.resolve(workingDir, outDir),
+                    entryDir: path.dirname(path.resolve(workingDir, outDir, computeName(entryNames, args.path, ''))),
                     target: [scriptsTarget, modulesTarget],
                 };
 

--- a/packages/esbuild-plugin-html/package.json
+++ b/packages/esbuild-plugin-html/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.15.37",
   "description": "A HTML loader plugin for esbuild.",
-  "main": "lib/index.js",
+  "main": "dist/index.js",
   "typings": "./types/index.d.ts",
   "author": "Chialab <dev@chialab.io> (https://www.chialab.it)",
   "license": "MIT",

--- a/packages/esbuild-plugin-html/package.json
+++ b/packages/esbuild-plugin-html/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.15.37",
   "description": "A HTML loader plugin for esbuild.",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "typings": "./types/index.d.ts",
   "author": "Chialab <dev@chialab.io> (https://www.chialab.it)",
   "license": "MIT",

--- a/packages/esbuild-plugin-html/test/test.spec.js
+++ b/packages/esbuild-plugin-html/test/test.spec.js
@@ -3,7 +3,7 @@ import htmlPlugin from '@chialab/esbuild-plugin-html';
 import virtualPlugin from '@chialab/esbuild-plugin-virtual';
 import { expect } from 'chai';
 
-describe('esbuild-plugin-html', () => {
+describe.only('esbuild-plugin-html', () => {
     it('should bundle webapp with scripts', async () => {
         const { outputFiles } = await esbuild.build({
             absWorkingDir: new URL('.', import.meta.url).pathname,
@@ -32,16 +32,26 @@ describe('esbuild-plugin-html', () => {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="1-R3ICRKFP.css">
+    <script type="application/javascript">
+        (function() {
+            function loadStyle(url) {
+                var l = document.createElement('link');
+                l.rel = 'stylesheet';
+                l.href = url;
+                document.head.appendChild(l);
+            }
+            loadStyle('index-UMVLUHQU.css');
+        }());
+    </script>
 </head>
 
 <body>
-    <script src="1-JOUMWTNZ.js" type="application/javascript"></script>
+    <script src="index-PASUIUF5.js" type="application/javascript"></script>
 </body>
 
 </html>`);
 
-        expect(js.path.endsWith('/out/1-JOUMWTNZ.js')).to.be.true;
+        expect(js.path.endsWith('/out/index-PASUIUF5.js')).to.be.true;
         expect(js.text).to.be.equal(`(() => {
   // fixture/lib.js
   var log = console.log.bind(console);
@@ -53,7 +63,7 @@ describe('esbuild-plugin-html', () => {
 })();
 `);
 
-        expect(css.path.endsWith('/out/1-R3ICRKFP.css')).to.be.true;
+        expect(css.path.endsWith('/out/index-UMVLUHQU.css')).to.be.true;
         expect(css.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
@@ -92,16 +102,26 @@ body {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="1-JIRSVTF3.css">
+    <script type="application/javascript">
+        (function() {
+            function loadStyle(url) {
+                var l = document.createElement('link');
+                l.rel = 'stylesheet';
+                l.href = url;
+                document.head.appendChild(l);
+            }
+            loadStyle('index-CECUKMCO.css');
+        }());
+    </script>
 </head>
 
 <body>
-    <script src="1-MFHSZCSP.js" type="application/javascript"></script>
+    <script src="index-2REWJ4YW.js" type="application/javascript"></script>
 </body>
 
 </html>`);
 
-        expect(js.path.endsWith('/out/1-MFHSZCSP.js')).to.be.true;
+        expect(js.path.endsWith('/out/index-2REWJ4YW.js')).to.be.true;
         expect(js.text).to.be.equal(`(() => {
   // fixture/lib.js
   var log = console.log.bind(console);
@@ -111,17 +131,17 @@ body {
     log("test");
   });
 })();
-//# sourceMappingURL=1-MFHSZCSP.js.map
+//# sourceMappingURL=index-2REWJ4YW.js.map
 `);
 
-        expect(css.path.endsWith('/out/1-JIRSVTF3.css')).to.be.true;
+        expect(css.path.endsWith('/out/index-CECUKMCO.css')).to.be.true;
         expect(css.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
   margin: 0;
   padding: 0;
 }
-/*# sourceMappingURL=1-JIRSVTF3.css.map */
+/*# sourceMappingURL=index-CECUKMCO.css.map */
 `);
     });
 
@@ -140,9 +160,13 @@ body {
             ],
         });
 
-        const [index, js, css] = outputFiles;
+        const [index, ...files] = outputFiles;
+        const jsFile = files.find((file) => file.path.includes('/out/index') && file.path.endsWith('.js'));
+        const jsSource = files.find((file) => file.path.includes('/out/1-') && file.path.endsWith('.js'));
+        const jsChunk = files.find((file) => file.path.includes('/out/chunk-') && file.path.endsWith('.js'));
+        const css = files.find((file) => file.path.endsWith('.css'));
 
-        expect(outputFiles).to.have.lengthOf(3);
+        expect(outputFiles).to.have.lengthOf(5);
 
         expect(index.path.endsWith('/out/index.esm.html')).to.be.true;
         expect(index.text).to.be.equal(`<!DOCTYPE html>
@@ -153,29 +177,58 @@ body {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="1-R3ICRKFP.css">
+    <script type="module">
+        (function() {
+            function loadStyle(url) {
+                var l = document.createElement('link');
+                l.rel = 'stylesheet';
+                l.href = url;
+                document.head.appendChild(l);
+            }
+            loadStyle('index-UMVLUHQU.css');
+        }());
+    </script>
 </head>
 
 <body>
-    <script src="1-6ZJC3XWM.js" type="module"></script>
+    <script src="index-7DQE4SCR.js" type="module"></script>
+    <script type="module">
+        import './1-ZOQZ7JHL.js'
+    </script>
 </body>
 
 </html>`);
 
-        expect(js.path.endsWith('1-6ZJC3XWM.js')).to.be.true;
-        expect(js.text).to.be.equal(`// fixture/lib.js
-var log = console.log.bind(console);
+        expect(jsFile.path.endsWith('index-7DQE4SCR.js')).to.be.true;
+        expect(jsFile.text).to.be.equal(`import {
+  log
+} from "./chunk-VLQWHBZB.js";
 
 // fixture/index.js
 window.addEventListener("load", () => {
   log("test");
 });
+`);
+
+        expect(jsSource.path.endsWith('/1-ZOQZ7JHL.js')).to.be.true;
+        expect(jsSource.text).to.be.equal(`import {
+  log
+} from "./chunk-VLQWHBZB.js";
 
 // fixture/1.js
 log("test");
 `);
 
-        expect(css.path.endsWith('1-R3ICRKFP.css')).to.be.true;
+        expect(jsChunk.path.endsWith('/chunk-VLQWHBZB.js')).to.be.true;
+        expect(jsChunk.text).to.be.equal(`// fixture/lib.js
+var log = console.log.bind(console);
+
+export {
+  log
+};
+`);
+
+        expect(css.path.endsWith('/index-UMVLUHQU.css')).to.be.true;
         expect(css.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
@@ -201,9 +254,14 @@ body {
             ],
         });
 
-        const [index, js, lib, chunk, css] = outputFiles;
+        const [index, ...files] = outputFiles;
+        const jsFile = files.find((file) => file.path.includes('/out/index') && file.path.endsWith('.js'));
+        const jsSource = files.find((file) => file.path.includes('/out/1-') && file.path.endsWith('.js'));
+        const jsLib = files.find((file) => file.path.includes('/out/lib-') && file.path.endsWith('.js'));
+        const jsChunk = files.find((file) => file.path.includes('/out/chunk-') && file.path.endsWith('.js'));
+        const css = files.find((file) => file.path.endsWith('.css'));
 
-        expect(outputFiles).to.have.lengthOf(5);
+        expect(outputFiles).to.have.lengthOf(6);
 
         expect(index.path.endsWith('/out/index.chunks.html')).to.be.true;
         expect(index.text).to.be.equal(`<!DOCTYPE html>
@@ -214,17 +272,30 @@ body {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="1-R3ICRKFP.css">
+    <script type="module">
+        (function() {
+            function loadStyle(url) {
+                var l = document.createElement('link');
+                l.rel = 'stylesheet';
+                l.href = url;
+                document.head.appendChild(l);
+            }
+            loadStyle('index-UMVLUHQU.css');
+        }());
+    </script>
 </head>
 
 <body>
-    <script src="1-CHKD3JX6.js" type="module"></script>
+    <script type="module">
+        import './1-GWHRC5DW.js'
+    </script>
+    <script src="index-NISLXZJK.js" type="module"></script>
 </body>
 
 </html>`);
 
-        expect(js.path.endsWith('1-CHKD3JX6.js')).to.be.true;
-        expect(js.text).to.be.equal(`import {
+        expect(jsFile.path.endsWith('/index-NISLXZJK.js')).to.be.true;
+        expect(jsFile.text).to.be.equal(`import {
   log
 } from "./chunk-GNFD7QL2.js";
 
@@ -232,15 +303,17 @@ body {
 window.addEventListener("load", () => {
   log("test");
 });
+`);
 
-// fixture/1.js
-import("./lib-476DRX7L.js").then(({ log: log2 }) => {
-  log2("test");
+        expect(jsSource.path.endsWith('/1-GWHRC5DW.js')).to.be.true;
+        expect(jsSource.text).to.be.equal(`// fixture/1.js
+import("./lib-476DRX7L.js").then(({ log }) => {
+  log("test");
 });
 `);
 
-        expect(lib.path.endsWith('lib-476DRX7L.js')).to.be.true;
-        expect(lib.text).to.be.equal(`import {
+        expect(jsLib.path.endsWith('/lib-476DRX7L.js')).to.be.true;
+        expect(jsLib.text).to.be.equal(`import {
   log
 } from "./chunk-GNFD7QL2.js";
 export {
@@ -248,8 +321,8 @@ export {
 };
 `);
 
-        expect(chunk.path.endsWith('chunk-GNFD7QL2.js')).to.be.true;
-        expect(chunk.text).to.be.equal(`// fixture/lib.js
+        expect(jsChunk.path.endsWith('/chunk-GNFD7QL2.js')).to.be.true;
+        expect(jsChunk.text).to.be.equal(`// fixture/lib.js
 var log = console.log.bind(console);
 
 export {
@@ -257,7 +330,7 @@ export {
 };
 `);
 
-        expect(css.path.endsWith('1-R3ICRKFP.css')).to.be.true;
+        expect(css.path.endsWith('/index-UMVLUHQU.css')).to.be.true;
         expect(css.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
@@ -283,9 +356,9 @@ body {
         });
 
         const index = /** @type {import('esbuild').OutputFile} */ (outputFiles.find((file) => file.path.endsWith('.html')));
-        const iife = /** @type {import('esbuild').OutputFile} */ (outputFiles.find((file) => file.path.endsWith('1-JOUMWTNZ.js')));
-        const esm = /** @type {import('esbuild').OutputFile} */ (outputFiles.find((file) => file.path.endsWith('2-T7UKAOZB.js')));
-        const esmCss = /** @type {import('esbuild').OutputFile} */ (outputFiles.find((file) => file.path.endsWith('2-KQM7Y3VQ.css')));
+        const iife = /** @type {import('esbuild').OutputFile} */ (outputFiles.find((file) => file.path.endsWith('index-PASUIUF5.js')));
+        const esm = /** @type {import('esbuild').OutputFile} */ (outputFiles.find((file) => file.path.endsWith('index-6PRLBFYO.js')));
+        const css = /** @type {import('esbuild').OutputFile} */ (outputFiles.find((file) => file.path.endsWith('index-UMVLUHQU.css')));
 
         expect(outputFiles).to.have.lengthOf(5);
 
@@ -298,17 +371,38 @@ body {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="2-KQM7Y3VQ.css">
+    <script type="module">
+        (function() {
+            function loadStyle(url) {
+                var l = document.createElement('link');
+                l.rel = 'stylesheet';
+                l.href = url;
+                document.head.appendChild(l);
+            }
+            loadStyle('index-UMVLUHQU.css');
+        }());
+    </script>
+    <script nomodule="" type="application/javascript">
+        (function() {
+            function loadStyle(url) {
+                var l = document.createElement('link');
+                l.rel = 'stylesheet';
+                l.href = url;
+                document.head.appendChild(l);
+            }
+            loadStyle('index-UMVLUHQU.css');
+        }());
+    </script>
 </head>
 
 <body>
-    <script src="1-JOUMWTNZ.js" type="application/javascript" nomodule=""></script>
-    <script src="2-T7UKAOZB.js" type="module"></script>
+    <script src="index-6PRLBFYO.js" type="module"></script>
+    <script src="index-PASUIUF5.js" type="application/javascript" nomodule=""></script>
 </body>
 
 </html>`);
 
-        expect(iife.path.endsWith('/out/1-JOUMWTNZ.js')).to.be.true;
+        expect(iife.path.endsWith('/out/index-PASUIUF5.js')).to.be.true;
         expect(iife.text).to.be.equal(`(() => {
   // fixture/lib.js
   var log = console.log.bind(console);
@@ -320,7 +414,7 @@ body {
 })();
 `);
 
-        expect(esm.path.endsWith('/out/2-T7UKAOZB.js')).to.be.true;
+        expect(esm.path.endsWith('/out/index-6PRLBFYO.js')).to.be.true;
         expect(esm.text).to.be.equal(`// fixture/lib.js
 var log = console.log.bind(console);
 
@@ -330,8 +424,8 @@ window.addEventListener("load", () => {
 });
 `);
 
-        expect(esmCss.path.endsWith('/out/2-KQM7Y3VQ.css')).to.be.true;
-        expect(esmCss.text).to.be.equal(`/* fixture/index.css */
+        expect(css.path.endsWith('/out/index-UMVLUHQU.css')).to.be.true;
+        expect(css.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
   margin: 0;
@@ -354,9 +448,11 @@ body {
             ],
         });
 
-        const [index, css] = outputFiles;
+        const [index, ...cssFiles] = outputFiles;
+        const cssFile = cssFiles.find((output) => output.path.includes('/out/index'));
+        const cssSource = cssFiles.find((output) => output.path.includes('/out/1-'));
 
-        expect(outputFiles).to.have.lengthOf(2);
+        expect(outputFiles).to.have.lengthOf(3);
 
         expect(index.path.endsWith('/out/index.css.html')).to.be.true;
         expect(index.text).to.be.equal(`<!DOCTYPE html>
@@ -367,7 +463,10 @@ body {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="1-OFYYZ7M5.css">
+    <link rel="stylesheet" href="index-UMVLUHQU.css">
+    <style>
+        @import '1-EKADEBHI.css'
+    </style>
 </head>
 
 <body>
@@ -375,15 +474,17 @@ body {
 
 </html>`);
 
-        expect(css.path.endsWith('/out/1-OFYYZ7M5.css')).to.be.true;
-        expect(css.text).to.be.equal(`/* fixture/index.css */
+        expect(cssFile.path.endsWith('/out/index-UMVLUHQU.css')).to.be.true;
+        expect(cssFile.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
   margin: 0;
   padding: 0;
 }
+`);
 
-/* fixture/1.css */
+        expect(cssSource.path.endsWith('/out/1-EKADEBHI.css')).to.be.true;
+        expect(cssSource.text).to.be.equal(`/* fixture/1.css */
 body {
   color: red;
 }
@@ -446,7 +547,7 @@ body {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="1-PQALMFMQ.css">
+    <link rel="stylesheet" href="index-JHCCFNW4.css">
 </head>
 
 <body>
@@ -454,15 +555,13 @@ body {
 
 </html>`);
 
-        expect(css.path.endsWith('/out/1-PQALMFMQ.css')).to.be.true;
+        expect(css.path.endsWith('/out/index-JHCCFNW4.css')).to.be.true;
         expect(css.text).to.be.equal(`/* lib.css */
 html {
   padding: 0;
 }
 
 /* index.css */
-
-/* 1.css */
 `);
     });
 
@@ -669,7 +768,7 @@ html {
 
         const [index, ...assets] = outputFiles;
         const icons = assets.slice(0, 9);
-        const manifest = assets[assets.length - 1];
+        const manifest = assets[9];
 
         expect(outputFiles).to.have.lengthOf(17);
 
@@ -717,47 +816,47 @@ html {
   "lang": "en",
   "icons": [
     {
-      "src": "./assets/android-chrome-36x36.png?hash=b3c59d86",
+      "src": "assets/android-chrome-36x36.png",
       "sizes": "36x36",
       "type": "image/png"
     },
     {
-      "src": "./assets/android-chrome-48x48.png?hash=888e8a41",
+      "src": "assets/android-chrome-48x48.png",
       "sizes": "48x48",
       "type": "image/png"
     },
     {
-      "src": "./assets/android-chrome-72x72.png?hash=7e749c52",
+      "src": "assets/android-chrome-72x72.png",
       "sizes": "72x72",
       "type": "image/png"
     },
     {
-      "src": "./assets/android-chrome-96x96.png?hash=760fa674",
+      "src": "assets/android-chrome-96x96.png",
       "sizes": "96x96",
       "type": "image/png"
     },
     {
-      "src": "./assets/android-chrome-144x144.png?hash=4dc61811",
+      "src": "assets/android-chrome-144x144.png",
       "sizes": "144x144",
       "type": "image/png"
     },
     {
-      "src": "./assets/android-chrome-192x192.png?hash=9a8c49b7",
+      "src": "assets/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "./assets/android-chrome-256x256.png?hash=19ceae5d",
+      "src": "assets/android-chrome-256x256.png",
       "sizes": "256x256",
       "type": "image/png"
     },
     {
-      "src": "./assets/android-chrome-384x384.png?hash=599c2926",
+      "src": "assets/android-chrome-384x384.png",
       "sizes": "384x384",
       "type": "image/png"
     },
     {
-      "src": "./assets/android-chrome-512x512.png?hash=373686d8",
+      "src": "assets/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/packages/esbuild-plugin-html/test/test.spec.js
+++ b/packages/esbuild-plugin-html/test/test.spec.js
@@ -3,7 +3,7 @@ import htmlPlugin from '@chialab/esbuild-plugin-html';
 import virtualPlugin from '@chialab/esbuild-plugin-virtual';
 import { expect } from 'chai';
 
-describe.only('esbuild-plugin-html', () => {
+describe('esbuild-plugin-html', () => {
     it('should bundle webapp with scripts', async () => {
         const { outputFiles } = await esbuild.build({
             absWorkingDir: new URL('.', import.meta.url).pathname,
@@ -520,7 +520,7 @@ body {
 `,
                     },
                     {
-                        path: './index.css',
+                        path: new URL('./index.css', import.meta.url).pathname,
                         contents: '@import \'lib.css\';',
                         loader: 'css',
                     },
@@ -881,7 +881,9 @@ html {
             ],
         });
 
-        const [index, js, css] = outputFiles;
+        const [index, ...files] = outputFiles;
+        const js = files.find((file) => file.path.endsWith('.js'));
+        const css = files.find((file) => file.path.endsWith('.css'));
 
         expect(outputFiles).to.have.lengthOf(3);
         expect(index.path.endsWith('/out/fixture/index.iife.html')).to.be.true;
@@ -893,17 +895,27 @@ html {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="../1.css">
+    <script type="application/javascript">
+        (function() {
+            function loadStyle(url) {
+                var l = document.createElement('link');
+                l.rel = 'stylesheet';
+                l.href = url;
+                document.head.appendChild(l);
+            }
+            loadStyle('../index.css');
+        }());
+    </script>
 </head>
 
 <body>
-    <script src="../1.js" type="application/javascript"></script>
+    <script src="../index.js" type="application/javascript"></script>
 </body>
 
 </html>`);
 
-        expect(js.path.endsWith('/out/1.js')).to.be.true;
-        expect(css.path.endsWith('/out/1.css')).to.be.true;
+        expect(js.path.endsWith('/out/index.js')).to.be.true;
+        expect(css.path.endsWith('/out/index.css')).to.be.true;
     });
 
     it('should bundle webapp with [dir] without outbase', async () => {
@@ -922,7 +934,9 @@ html {
             ],
         });
 
-        const [index, js, css] = outputFiles;
+        const [index, ...files] = outputFiles;
+        const js = files.find((file) => file.path.endsWith('.js'));
+        const css = files.find((file) => file.path.endsWith('.css'));
 
         expect(outputFiles).to.have.lengthOf(3);
         expect(index.path.endsWith('/out/index.iife.html')).to.be.true;
@@ -934,16 +948,26 @@ html {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-    <link rel="stylesheet" href="1.css">
+    <script type="application/javascript">
+        (function() {
+            function loadStyle(url) {
+                var l = document.createElement('link');
+                l.rel = 'stylesheet';
+                l.href = url;
+                document.head.appendChild(l);
+            }
+            loadStyle('index.css');
+        }());
+    </script>
 </head>
 
 <body>
-    <script src="1.js" type="application/javascript"></script>
+    <script src="index.js" type="application/javascript"></script>
 </body>
 
 </html>`);
 
-        expect(js.path.endsWith('/out/1.js')).to.be.true;
-        expect(css.path.endsWith('/out/1.css')).to.be.true;
+        expect(js.path.endsWith('/out/index.js')).to.be.true;
+        expect(css.path.endsWith('/out/index.css')).to.be.true;
     });
 });

--- a/packages/esbuild-plugin-require-resolve/lib/index.js
+++ b/packages/esbuild-plugin-require-resolve/lib/index.js
@@ -59,7 +59,7 @@ export default function() {
                         });
 
                         const emittedFile = await emitFile(resolvedFilePath);
-                        helpers.overwrite(stringToken.start, stringToken.end, appendSearchParam(`'./${emittedFile.path}'`, 'hash', emittedFile.id));
+                        helpers.overwrite(stringToken.start, stringToken.end, `'./${appendSearchParam(emittedFile.path, 'hash', emittedFile.id)}'`);
                     })());
                 });
 

--- a/packages/esbuild-plugin-require-resolve/lib/index.js
+++ b/packages/esbuild-plugin-require-resolve/lib/index.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import { TokenType, parse, walk } from '@chialab/estransform';
+import { appendSearchParam } from '@chialab/node-resolve';
 import { useRna } from '@chialab/esbuild-rna';
 
 /**
@@ -57,8 +58,8 @@ export default function() {
                             resolveDir: path.dirname(args.path),
                         });
 
-                        const emittedFile = (await emitFile(resolvedFilePath)).path;
-                        helpers.overwrite(stringToken.start, stringToken.end, `'${emittedFile}'`);
+                        const emittedFile = await emitFile(resolvedFilePath);
+                        helpers.overwrite(stringToken.start, stringToken.end, appendSearchParam(`'./${emittedFile.path}'`, 'hash', emittedFile.id));
                     })());
                 });
 

--- a/packages/esbuild-plugin-require-resolve/package.json
+++ b/packages/esbuild-plugin-require-resolve/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "@chialab/esbuild-rna": "^0.15.37",
-    "@chialab/estransform": "^0.15.28"
+    "@chialab/estransform": "^0.15.28",
+    "@chialab/node-resolve": "^0.15.28"
   },
   "devDependencies": {
     "typescript": "^4.3.0"

--- a/packages/esbuild-plugin-require-resolve/tsconfig.json
+++ b/packages/esbuild-plugin-require-resolve/tsconfig.json
@@ -15,6 +15,9 @@
     },
     {
       "path": "../estransform"
+    },
+    {
+      "path": "../node-resolve"
     }
   ]
 }

--- a/packages/esbuild-plugin-virtual/lib/index.js
+++ b/packages/esbuild-plugin-virtual/lib/index.js
@@ -1,17 +1,7 @@
-import path from 'path';
-import { escapeRegexBody } from '@chialab/node-resolve';
 import { useRna } from '@chialab/esbuild-rna';
 
 /**
- * @typedef {Object} VirtualEntry
- * @property {string} path
- * @property {string|Buffer} contents
- * @property {import('esbuild').Loader} [loader]
- * @property {string} [resolveDir]
- */
-
-/**
- * @typedef {VirtualEntry[]} PluginOptions
+ * @typedef {import('@chialab/esbuild-rna').VirtualEntry[]} PluginOptions
  */
 
 /**
@@ -37,27 +27,9 @@ export default function virtual(entries) {
     const plugin = {
         name: this?.name || 'virtual',
         async setup(build) {
-            const { onLoad, rootDir, loaders } = useRna(build);
+            const { addVirtualModule } = useRna(build);
 
-            entries.forEach((entry) => {
-                const resolveDir = entry.resolveDir || rootDir;
-                const virtualFilePath = path.isAbsolute(entry.path) ? entry.path : path.join(resolveDir, entry.path);
-                const filter = new RegExp(`^${escapeRegexBody(entry.path)}$`);
-                const entryFilter = new RegExp(escapeRegexBody(virtualFilePath));
-
-                build.onResolve({ filter }, () => ({
-                    path: virtualFilePath,
-                    namespace: 'file',
-                }));
-
-                onLoad({ filter: entryFilter }, (args) => ({
-                    ...args,
-                    contents: entry.contents,
-                    namespace: 'file',
-                    loader: entry.loader || loaders[path.extname(args.path)] || 'file',
-                    resolveDir,
-                }));
-            });
+            entries.forEach((entry) => addVirtualModule(entry));
         },
     };
 

--- a/packages/esbuild-plugin-virtual/package.json
+++ b/packages/esbuild-plugin-virtual/package.json
@@ -24,8 +24,7 @@
     "node": ">=13"
   },
   "dependencies": {
-    "@chialab/esbuild-rna": "^0.15.37",
-    "@chialab/node-resolve": "^0.15.28"
+    "@chialab/esbuild-rna": "^0.15.37"
   },
   "devDependencies": {
     "typescript": "^4.3.0"

--- a/packages/esbuild-plugin-virtual/tsconfig.json
+++ b/packages/esbuild-plugin-virtual/tsconfig.json
@@ -12,9 +12,6 @@
   "references": [
     {
       "path": "../esbuild-rna"
-    },
-    {
-      "path": "../node-resolve"
     }
   ]
 }

--- a/packages/esbuild-plugin-worker/package.json
+++ b/packages/esbuild-plugin-worker/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "@chialab/esbuild-plugin-meta-url": "^0.15.40",
     "@chialab/esbuild-rna": "^0.15.39",
-    "@chialab/estransform": "^0.15.28"
+    "@chialab/estransform": "^0.15.28",
+    "@chialab/node-resolve": "^0.15.28"
   },
   "devDependencies": {
     "typescript": "^4.3.0"

--- a/packages/esbuild-plugin-worker/tsconfig.json
+++ b/packages/esbuild-plugin-worker/tsconfig.json
@@ -18,6 +18,9 @@
     },
     {
       "path": "../estransform"
+    },
+    {
+      "path": "../node-resolve"
     }
   ]
 }

--- a/packages/esbuild-rna/lib/index.js
+++ b/packages/esbuild-rna/lib/index.js
@@ -669,18 +669,20 @@ export function useRna(build) {
             rnaBuild.chunks.forEach((result) => assignToResult(rnaResult, result));
             rnaBuild.files.forEach((result) => assignToResult(rnaResult, result));
 
-            const outputs = { ...rnaResult.metafile.outputs };
-            for (const outputKey in outputs) {
-                const output = outputs[outputKey];
-                if (!output.entryPoint) {
-                    continue;
+            if (rnaResult.metafile) {
+                const outputs = { ...rnaResult.metafile.outputs };
+                for (const outputKey in outputs) {
+                    const output = outputs[outputKey];
+                    if (!output.entryPoint) {
+                        continue;
+                    }
+
+                    const entryPoint = path.resolve(rootDir, output.entryPoint.split('?')[0]);
+                    const dependencies = Object.keys(output.inputs)
+                        .map((input) => path.resolve(rootDir, input.split('?')[0]));
+
+                    rnaBuild.collectDependencies(entryPoint, dependencies);
                 }
-
-                const entryPoint = path.resolve(rootDir, output.entryPoint.split('?')[0]);
-                const dependencies = Object.keys(output.inputs)
-                    .map((input) => path.resolve(rootDir, input.split('?')[0]));
-
-                rnaBuild.collectDependencies(entryPoint, dependencies);
             }
         });
     }

--- a/packages/esbuild-rna/lib/index.js
+++ b/packages/esbuild-rna/lib/index.js
@@ -709,12 +709,7 @@ export function useRna(build) {
             const virtualFilePath = path.isAbsolute(entry.path) ? entry.path : path.join(resolveDir, entry.path);
             const virtualFilter = new RegExp(escapeRegexBody(virtualFilePath));
 
-            build.onResolve({ filter: new RegExp(escapeRegexBody(entry.path)) }, () => ({
-                path: virtualFilePath,
-                namespace: 'file',
-            }));
-
-            build.onResolve({ filter: virtualFilter }, () => ({
+            build.onResolve({ filter: new RegExp(`^${escapeRegexBody(entry.path)}$`) }, () => ({
                 path: virtualFilePath,
                 namespace: 'file',
             }));

--- a/packages/rna-bundler/lib/index.js
+++ b/packages/rna-bundler/lib/index.js
@@ -158,7 +158,9 @@ export function command(program) {
                     plugins: [
                         ...await Promise.all([
                             import('@chialab/esbuild-plugin-html')
-                                .then(({ default: plugin }) => plugin()),
+                                .then(({ default: plugin }) => plugin({
+                                    modulesTarget: userConfig.target || 'es2020',
+                                })),
                             import('@chialab/esbuild-plugin-postcss')
                                 .then(({ default: plugin }) => plugin())
                                 .catch(() => ({ name: 'postcss', setup() { } })),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,6 +1818,7 @@ __metadata:
   dependencies:
     "@chialab/esbuild-rna": ^0.15.37
     "@chialab/estransform": ^0.15.28
+    "@chialab/node-resolve": ^0.15.28
     typescript: ^4.3.0
   languageName: unknown
   linkType: soft
@@ -1838,7 +1839,6 @@ __metadata:
   resolution: "@chialab/esbuild-plugin-virtual@workspace:packages/esbuild-plugin-virtual"
   dependencies:
     "@chialab/esbuild-rna": ^0.15.37
-    "@chialab/node-resolve": ^0.15.28
     typescript: ^4.3.0
   languageName: unknown
   linkType: soft
@@ -1850,6 +1850,7 @@ __metadata:
     "@chialab/esbuild-plugin-meta-url": ^0.15.40
     "@chialab/esbuild-rna": ^0.15.39
     "@chialab/estransform": ^0.15.28
+    "@chialab/node-resolve": ^0.15.28
     typescript: ^4.3.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
At the moment, the html plugin collapse JS and CSS files as single imports at the end of the HTML file. After this refactor, the plugin will exec a build using multiple entrypoints in order to update existing `<script>`, `<style>` and `<link>` references.