### PR TITLE
Refactor load callback

### DIFF
--- a/.changeset/orange-beers-yell.md
+++ b/.changeset/orange-beers-yell.md
@@ -1,0 +1,16 @@
+---
+"@chialab/es-dev-server": patch
+"@chialab/es-test-runner": patch
+"@chialab/esbuild-plugin-html": patch
+"@chialab/esbuild-plugin-postcss": patch
+"@chialab/esbuild-rna": patch
+"@chialab/estransform": patch
+"@chialab/node-resolve": patch
+"@chialab/rna-dev-server": patch
+"@chialab/rna-logger": patch
+"@chialab/rna-storybook": patch
+"@chialab/rna": patch
+"@chialab/wtr-mocha-reporter": patch
+---
+
+Refactor load callback

--- a/packages/es-dev-server/build.js
+++ b/packages/es-dev-server/build.js
@@ -5,7 +5,7 @@ esbuild.build({
     outdir: 'dist',
     bundle: true,
     splitting: false,
-    minify: true,
+    minify: false,
     sourcemap: true,
     format: 'esm',
     platform: 'node',

--- a/packages/es-test-runner/build.js
+++ b/packages/es-test-runner/build.js
@@ -5,7 +5,7 @@ esbuild.build({
     outdir: 'dist',
     bundle: true,
     splitting: false,
-    minify: true,
+    minify: false,
     sourcemap: true,
     format: 'esm',
     platform: 'node',

--- a/packages/esbuild-plugin-html/build.js
+++ b/packages/esbuild-plugin-html/build.js
@@ -5,7 +5,7 @@ esbuild.build({
     outdir: 'dist',
     bundle: true,
     splitting: false,
-    minify: true,
+    minify: false,
     sourcemap: true,
     format: 'esm',
     platform: 'node',

--- a/packages/esbuild-plugin-html/lib/collectIcons.js
+++ b/packages/esbuild-plugin-html/lib/collectIcons.js
@@ -149,7 +149,7 @@ async function collectAppleIcons($, dom, options, helpers) {
     }
 
     const iconFile = await helpers.load(iconFilePath.path, iconFilePath);
-    if (!iconFile.contents) {
+    if (!iconFile || !iconFile.contents) {
         throw new Error(`Failed to load icon file: ${iconFilePath.path}`);
     }
 
@@ -197,7 +197,7 @@ export async function collectIcons($, dom, options, helpers) {
     }
 
     const iconFile = await load(iconFilePath.path, iconFilePath);
-    if (!iconFile.contents) {
+    if (!iconFile || !iconFile.contents) {
         throw new Error(`Failed to load icon file: ${iconFilePath.path}`);
     }
 

--- a/packages/esbuild-plugin-html/lib/collectScreens.js
+++ b/packages/esbuild-plugin-html/lib/collectScreens.js
@@ -116,7 +116,7 @@ export async function collectScreens($, dom, options, helpers) {
     }
 
     const splashFile = await helpers.load(splashFilePath.path, splashFilePath);
-    if (!splashFile.contents) {
+    if (!splashFile || !splashFile.contents) {
         throw new Error(`Failed to load icon file: ${splashFilePath.path}`);
     }
 

--- a/packages/esbuild-plugin-html/lib/collectWebManifest.js
+++ b/packages/esbuild-plugin-html/lib/collectWebManifest.js
@@ -68,7 +68,7 @@ export async function collectWebManifest($, dom, options, helpers) {
     }
 
     const manifestFile = await helpers.load(manifestFilePath.path, manifestFilePath);
-    if (!manifestFile.contents) {
+    if (!manifestFile || !manifestFile.contents) {
         throw new Error(`Failed to load manifest file: ${manifestFilePath.path}`);
     }
 
@@ -92,7 +92,7 @@ export async function collectWebManifest($, dom, options, helpers) {
         }
 
         const iconFile = await helpers.load(iconFilePath.path, iconFilePath);
-        if (!iconFile.contents) {
+        if (!iconFile || !iconFile.contents) {
             throw new Error(`Failed to load icon file: ${iconFilePath.path}`);
         }
 

--- a/packages/esbuild-plugin-html/lib/index.js
+++ b/packages/esbuild-plugin-html/lib/index.js
@@ -38,7 +38,7 @@ const loadHtml = /** @type {typeof cheerio.load} */ (cheerio.load || cheerio.def
  * @property {(options: import('@chialab/esbuild-rna').EmitChunkOptions) => Promise<import('@chialab/esbuild-rna').Chunk>} emitChunk
  * @property {(options: import('@chialab/esbuild-rna').EmitBuildOptions) => Promise<import('@chialab/esbuild-rna').Result>} emitBuild
  * @property {(file: string) => Promise<import('esbuild').OnResolveResult>} resolve
- * @property {(file: string, options: Partial<import('esbuild').OnLoadArgs>) => Promise<import('esbuild').OnLoadResult>} load
+ * @property {(file: string, options: Partial<import('esbuild').OnLoadArgs>) => Promise<import('esbuild').OnLoadResult | undefined>} load
  */
 
 /**

--- a/packages/esbuild-plugin-postcss/lib/index.js
+++ b/packages/esbuild-plugin-postcss/lib/index.js
@@ -144,6 +144,10 @@ export default function(options = {}) {
                                                         pluginData: null,
                                                     });
 
+                                                    if (!loadResult) {
+                                                        throw new Error('No contents');
+                                                    }
+
                                                     const importResult = {
                                                         file: result.path,
                                                         contents: (/** @type {Buffer} */ (loadResult.contents)).toString(),

--- a/packages/estransform/build.js
+++ b/packages/estransform/build.js
@@ -5,7 +5,7 @@ esbuild.build({
     outdir: 'dist',
     bundle: true,
     splitting: false,
-    minify: true,
+    minify: false,
     sourcemap: true,
     format: 'esm',
     platform: 'node',

--- a/packages/node-resolve/build.js
+++ b/packages/node-resolve/build.js
@@ -5,7 +5,7 @@ esbuild.build({
     outdir: 'dist',
     bundle: true,
     splitting: false,
-    minify: true,
+    minify: false,
     sourcemap: true,
     format: 'esm',
     platform: 'node',

--- a/packages/rna-dev-server/build.js
+++ b/packages/rna-dev-server/build.js
@@ -6,7 +6,7 @@ esbuild.build({
     outdir: 'dist',
     bundle: true,
     splitting: false,
-    minify: true,
+    minify: false,
     sourcemap: true,
     format: 'esm',
     platform: 'node',

--- a/packages/rna-logger/build.js
+++ b/packages/rna-logger/build.js
@@ -5,7 +5,7 @@ esbuild.build({
     outdir: 'dist',
     bundle: true,
     splitting: false,
-    minify: true,
+    minify: false,
     sourcemap: true,
     format: 'esm',
     platform: 'node',

--- a/packages/rna-storybook/build.js
+++ b/packages/rna-storybook/build.js
@@ -5,7 +5,7 @@ esbuild.build({
     outdir: 'dist',
     bundle: true,
     splitting: false,
-    minify: true,
+    minify: false,
     sourcemap: true,
     format: 'esm',
     platform: 'node',

--- a/packages/rna/build.js
+++ b/packages/rna/build.js
@@ -5,7 +5,7 @@ esbuild.build({
     outdir: 'dist',
     bundle: true,
     splitting: false,
-    minify: true,
+    minify: false,
     sourcemap: true,
     format: 'esm',
     platform: 'node',

--- a/packages/wtr-mocha-reporter/build.js
+++ b/packages/wtr-mocha-reporter/build.js
@@ -5,7 +5,7 @@ esbuild.build({
     outdir: 'dist',
     bundle: true,
     splitting: false,
-    minify: true,
+    minify: false,
     sourcemap: true,
     format: 'esm',
     platform: 'node',


### PR DESCRIPTION
The `load` method from the rna framework throws an exception if unable to load a module. This PR fixes this behaviour by ignoring missing modules.