### PR TITLE
Fix Windows path as url

### DIFF
--- a/.changeset/popular-apricots-tie.md
+++ b/.changeset/popular-apricots-tie.md
@@ -1,0 +1,20 @@
+---
+"@chialab/es-dev-server": patch
+"@chialab/es-test-runner": patch
+"@chialab/esbuild-plugin-alias": patch
+"@chialab/esbuild-plugin-any-file": patch
+"@chialab/esbuild-plugin-babel": patch
+"@chialab/esbuild-plugin-commonjs": patch
+"@chialab/esbuild-plugin-css-import": patch
+"@chialab/esbuild-plugin-define-this": patch
+"@chialab/esbuild-plugin-env": patch
+"@chialab/esbuild-plugin-external": patch
+"@chialab/esbuild-plugin-html": patch
+"@chialab/esbuild-plugin-meta-url": patch
+"@chialab/esbuild-plugin-postcss": patch
+"@chialab/esbuild-plugin-unwebpack": patch
+"@chialab/esbuild-plugin-virtual": patch
+"@chialab/esbuild-plugin-worker": patch
+---
+
+Replace Windows path separator with forward slash when used as url

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,13 +36,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,23 +46,27 @@ jobs:
       - name: Install project dependencies
         run: yarn install
 
-      - name: Upload build artifacts
-        uses: actions/cache@v3
-        with:
-          path: ./packages
-          key: build-packages-${{ github.sha }}
-
       - name: Run typings script
         run: yarn types
 
       - name: Run build script
         run: yarn build
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: ./packages
+          retention-days: 7
+
   test:
     name: Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
     needs: build
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -73,14 +77,14 @@ jobs:
           node-version: 16
           cache: yarn
 
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: ./packages
+
       - name: Install project dependencies
         run: yarn install
-
-      - name: Fetch build artifacts
-        uses: actions/cache@v3
-        with:
-          path: ./packages
-          key: build-packages-${{ github.sha }}
 
       - name: Run tests
         run: yarn test
@@ -106,14 +110,14 @@ jobs:
           node-version: 16
           cache: yarn
 
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: ./packages
+
       - name: Install project dependencies
         run: yarn install
-
-      - name: Fetch build artifacts
-        uses: actions/cache@v3
-        with:
-          path: ./packages
-          key: build-packages-${{ github.sha }}
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
@@ -35,10 +35,10 @@ jobs:
     needs: lint
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
@@ -47,7 +47,7 @@ jobs:
         run: yarn install
 
       - name: Upload build artifacts
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./packages
           key: build-packages-${{ github.sha }}
@@ -68,10 +68,10 @@ jobs:
     needs: build
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
@@ -80,7 +80,7 @@ jobs:
         run: yarn install
 
       - name: Fetch build artifacts
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./packages
           key: build-packages-${{ github.sha }}
@@ -89,7 +89,7 @@ jobs:
         run: yarn test
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: coverage/lcov.info
 
@@ -101,10 +101,10 @@ jobs:
       - test
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
@@ -113,14 +113,14 @@ jobs:
         run: yarn install
 
       - name: Fetch build artifacts
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./packages
           key: build-packages-${{ github.sha }}
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v3
         with:
           version: yarn version
           publish: yarn changeset publish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,10 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     needs: build
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,10 +60,7 @@ jobs:
 
   test:
     name: Test
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: build
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,10 +30,7 @@ jobs:
   build:
     name: Build
     needs: lint
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -51,7 +48,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./packages
-          key: build-packages-${{ matrix.os }}-${{ github.sha }}
+          key: build-packages-${{ github.sha }}
 
       - name: Run typings script
         run: yarn types
@@ -84,7 +81,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./packages
-          key: build-packages-${{ matrix.os }}-${{ github.sha }}
+          key: build-packages-${{ github.sha }}
 
       - name: Run tests
         run: yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,10 +13,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
@@ -33,10 +33,10 @@ jobs:
     needs: lint
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
@@ -45,7 +45,7 @@ jobs:
         run: yarn install
 
       - name: Upload build artifacts
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./packages
           key: build-packages-${{ github.sha }}
@@ -66,10 +66,10 @@ jobs:
     needs: build
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn
@@ -78,7 +78,7 @@ jobs:
         run: yarn install
 
       - name: Fetch build artifacts
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./packages
           key: build-packages-${{ github.sha }}
@@ -87,6 +87,6 @@ jobs:
         run: yarn test
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: coverage/lcov.info

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,8 +29,11 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -48,7 +51,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./packages
-          key: build-packages-${{ github.sha }}
+          key: build-packages-${{ matrix.os }}-${{ github.sha }}
 
       - name: Run typings script
         run: yarn types
@@ -58,12 +61,12 @@ jobs:
 
   test:
     name: Test
+    needs: build
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
-    needs: build
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -81,7 +84,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./packages
-          key: build-packages-${{ github.sha }}
+          key: build-packages-${{ matrix.os }}-${{ github.sha }}
 
       - name: Run tests
         run: yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           name: packages
           path: ./packages
+          retention-days: 1
 
   test:
     name: Test
@@ -74,13 +75,14 @@ jobs:
           node-version: 16
           cache: yarn
 
-      - name: Install project dependencies
-        run: yarn install
-
-      - name: Fetch build artifacts
+      - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
           name: packages
+          path: ./packages
+
+      - name: Install project dependencies
+        run: yarn install
 
       - name: Run tests
         run: yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,10 +45,10 @@ jobs:
         run: yarn install
 
       - name: Upload build artifacts
-        uses: actions/cache@v3
+        uses: actions/upload-artifact@v3
         with:
+          name: packages
           path: ./packages
-          key: build-packages-${{ github.sha }}
 
       - name: Run typings script
         run: yarn types
@@ -78,10 +78,9 @@ jobs:
         run: yarn install
 
       - name: Fetch build artifacts
-        uses: actions/cache@v3
+        uses: actions/download-artifact@v3
         with:
-          path: ./packages
-          key: build-packages-${{ github.sha }}
+          name: packages
 
       - name: Run tests
         run: yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,17 +44,17 @@ jobs:
       - name: Install project dependencies
         run: yarn install
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: packages
-          path: ./packages
-
       - name: Run typings script
         run: yarn types
 
       - name: Run build script
         run: yarn build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: ./packages
 
   test:
     name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,7 +58,10 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     needs: build
     steps:

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -17,7 +17,7 @@ jobs:
     name: Wiki
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Push documentation to wiki
         env:
           GITHUB_TOKEN: ${{ secrets.GH_WIKI_TOKEN }}

--- a/internals/scripts/tsconfig.js
+++ b/internals/scripts/tsconfig.js
@@ -1,9 +1,10 @@
 import { readFile, writeFile } from 'fs/promises';
 import { relative, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { Configuration, Project } from '@yarnpkg/core';
 import { modify, applyEdits } from 'jsonc-parser';
 
-const ROOT = resolve(new URL(import.meta.url).pathname, '../../../');
+const ROOT = resolve(fileURLToPath(import.meta.url), '../../../');
 const config = Configuration.create(ROOT, ROOT);
 
 Project.find(config, ROOT)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/chai": "^4.2.22",
     "@yarnpkg/core": "^4.0.0-rc.6",
     "chai": "^4.3.4",
+    "chai-string": "^1.5.0",
     "eslint": "^8.0.0",
     "jsonc-parser": "^3.0.0",
     "plop": "^2.7.4",

--- a/packages/es-dev-server/build.js
+++ b/packages/es-dev-server/build.js
@@ -15,9 +15,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/es-test-runner/build.js
+++ b/packages/es-test-runner/build.js
@@ -17,9 +17,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/esbuild-plugin-alias/test/test.spec.js
+++ b/packages/esbuild-plugin-alias/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import aliasPlugin, { createAliasPlugin } from '@chialab/esbuild-plugin-alias';
 import { expect } from 'chai';
@@ -5,9 +6,9 @@ import { expect } from 'chai';
 describe('esbuild-plugin-alias', () => {
     it('should use alias instead of given import', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                sourcefile: new URL(import.meta.url).pathname,
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `import path from 'path';
 import { readFile } from 'fs/promises';
 
@@ -40,9 +41,9 @@ export {
 
     it('should use empty module instead of given import', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                sourcefile: new URL(import.meta.url).pathname,
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `import path from 'path';
 import fs from 'fs/promises';
 
@@ -75,9 +76,9 @@ export {
 
     it('should use alias instead of given import with a new plugin instance', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                sourcefile: new URL(import.meta.url).pathname,
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `import path from 'path';
 import { readFile } from 'fs/promises';
 
@@ -113,9 +114,9 @@ export {
 
     it('should read browser alias with browser platform', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.js', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.js', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             format: 'esm',
             platform: 'browser',
             target: 'esnext',
@@ -141,9 +142,9 @@ export {
 
     it('should not read browser alias with node platform', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.js', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.js', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             format: 'esm',
             platform: 'node',
             target: 'esnext',

--- a/packages/esbuild-plugin-any-file/test/test.spec.js
+++ b/packages/esbuild-plugin-any-file/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import anyFilePlugin from '@chialab/esbuild-plugin-any-file';
 import { expect } from 'chai';
@@ -5,10 +6,10 @@ import { expect } from 'chai';
 describe('esbuild-plugin-any-file', () => {
     it('should load a file with unknown loader', async () => {
         const { outputFiles: [file, result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `export * from './fs.js';
 import file from './unknown';
 export default file;`,
@@ -39,10 +40,10 @@ export default file;`,
         let err;
         try {
             await esbuild.build({
-                absWorkingDir: new URL('.', import.meta.url).pathname,
+                absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
                 stdin: {
-                    resolveDir: new URL('.', import.meta.url).pathname,
-                    sourcefile: new URL(import.meta.url).pathname,
+                    resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                    sourcefile: fileURLToPath(import.meta.url),
                     contents: `import file from './missing';
 export default file;`,
                 },
@@ -52,7 +53,7 @@ export default file;`,
                     {
                         name: 'resolve',
                         setup(build) {
-                            build.onResolve({ filter: /missing/ }, (args) => ({ path: new URL(args.path, import.meta.url).pathname }));
+                            build.onResolve({ filter: /missing/ }, (args) => ({ path: fileURLToPath(new URL(args.path, import.meta.url)) }));
                         },
                     },
                     anyFilePlugin({ shouldThrow: true }),

--- a/packages/esbuild-plugin-babel/lib/index.js
+++ b/packages/esbuild-plugin-babel/lib/index.js
@@ -1,8 +1,9 @@
+import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import babel from '@babel/core';
 import { useRna } from '@chialab/esbuild-rna';
 
-const resolveDir = dirname(new URL(import.meta.url).pathname);
+const resolveDir = dirname(fileURLToPath(import.meta.url));
 
 /**
  * @typedef {{ presets?: import('@babel/core').PluginItem[], plugins?: import('@babel/core').PluginItem[] }} PluginOptions

--- a/packages/esbuild-plugin-babel/test/test.spec.js
+++ b/packages/esbuild-plugin-babel/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import babelPlugin from '@chialab/esbuild-plugin-babel';
 import { expect } from 'chai';
@@ -5,10 +6,10 @@ import { expect } from 'chai';
 describe('esbuild-plugin-babel', () => {
     it('should transform code to es5', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const nil = () => {};',
             },
             target: 'es5',
@@ -31,9 +32,9 @@ export {
 
     it('should transform code using babel config', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.js', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.js', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             format: 'esm',
             bundle: true,
             write: false,
@@ -53,10 +54,10 @@ export {
 
     it('should transform using babel runtime', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const nil = async () => {};',
             },
             target: 'es5',
@@ -94,10 +95,10 @@ export {
 
     it('should bundle babel runtime', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const map = { ...{} }',
             },
             target: 'es5',
@@ -155,10 +156,10 @@ export {
 
     it('should convert tagget templates like jsx', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const template = html`<div />`;',
             },
             target: 'es5',

--- a/packages/esbuild-plugin-commonjs/test/test.spec.js
+++ b/packages/esbuild-plugin-commonjs/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import commonjsPlugin from '@chialab/esbuild-plugin-commonjs';
 import { expect } from 'chai';
@@ -5,10 +6,10 @@ import { expect } from 'chai';
 describe('esbuild-plugin-commonjs', () => {
     it('should skip if target is not esm', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `module.exports = {
     method() {
         return true;
@@ -35,10 +36,10 @@ module.exports = {
 
     it('should export legacy module with default specifier', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `module.exports = {
     method() {
         return true;
@@ -83,10 +84,10 @@ export {
 
     it('should bundle using the commonjs helper', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `module.exports = {
     method() {
         return require('fs');
@@ -203,10 +204,10 @@ export {
 
     it('should rename require in mixed modules', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `export default {
     method() {
         if (typeof require === 'function') {

--- a/packages/esbuild-plugin-css-import/test/test.spec.js
+++ b/packages/esbuild-plugin-css-import/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import cssImportPlugin from '@chialab/esbuild-plugin-css-import';
 import { expect } from 'chai';
@@ -5,9 +6,9 @@ import { expect } from 'chai';
 describe('esbuild-plugin-css-import', () => {
     it('should resolve css imports', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.css', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.css', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             bundle: true,
             write: false,
             plugins: [
@@ -28,9 +29,9 @@ body {
 
     it('should ignore external modules', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.css', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.css', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             bundle: true,
             write: false,
             external: [

--- a/packages/esbuild-plugin-define-this/test/test.spec.js
+++ b/packages/esbuild-plugin-define-this/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import defineThisPlugin from '@chialab/esbuild-plugin-define-this';
 import { expect } from 'chai';
@@ -5,10 +6,10 @@ import { expect } from 'chai';
 describe('esbuild-plugin-define-this', () => {
     it('should resolve to window for browser platform', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: '(function(g) { return g; }(this));',
             },
             platform: 'browser',
@@ -30,10 +31,10 @@ describe('esbuild-plugin-define-this', () => {
 
     it('should resolve to globalThis for neutral platform', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: '(function(g) { return g; }(this));',
             },
             platform: 'neutral',
@@ -53,10 +54,10 @@ describe('esbuild-plugin-define-this', () => {
 
     it('should resolve to undefined for node platform', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: '(function(g) { return g; }(this));',
             },
             platform: 'node',

--- a/packages/esbuild-plugin-env/test/test.spec.js
+++ b/packages/esbuild-plugin-env/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import envPlugin from '@chialab/esbuild-plugin-env';
 import { expect } from 'chai';
@@ -6,10 +7,10 @@ describe('esbuild-plugin-env', () => {
     it('should inject env values', async () => {
         process.env.CUSTOM_VAR = 'test';
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `export const custom = process.env.CUSTOM_VAR;
 export default process.env.NODE_ENV;`,
             },
@@ -33,10 +34,10 @@ export {
 
     it('should handle missing values', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `export const custom = process.env.MISSING_VAR;
 export default process.env.NODE_ENV;`,
             },
@@ -64,10 +65,10 @@ export {
     it('should handle invalid identifiers', async () => {
         process.env['INVALID-IDENTIFIER'] = true;
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export default process.env.NODE_ENV;',
             },
             format: 'esm',
@@ -88,10 +89,10 @@ export {
 
     it('should skip injection for node plaform', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export default process.env.NODE_ENV;',
             },
             format: 'esm',

--- a/packages/esbuild-plugin-external/test/test.spec.js
+++ b/packages/esbuild-plugin-external/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import externalPlugin from '@chialab/esbuild-plugin-external';
 import { expect } from 'chai';
@@ -5,10 +6,10 @@ import { expect } from 'chai';
 describe('esbuild-plugin-external', () => {
     it('should externalize remote modules', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `import { render } from 'https://unpkg.com/@chialab/dna';
                 export { render }`,
             },
@@ -30,9 +31,9 @@ export {
 
     it('should externalize dependencies', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.js', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.js', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             format: 'esm',
             bundle: true,
             write: false,
@@ -62,9 +63,9 @@ export {
 
     it('should externalize all dependencies', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.js', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.js', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             format: 'esm',
             bundle: true,
             write: false,
@@ -88,9 +89,9 @@ export {
 
     it('should externalize given deps', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.js', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.js', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             format: 'esm',
             bundle: true,
             write: false,
@@ -114,9 +115,9 @@ export {
 
     it('should skip without bundle', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.js', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.js', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             format: 'esm',
             bundle: false,
             write: false,

--- a/packages/esbuild-plugin-html/build.js
+++ b/packages/esbuild-plugin-html/build.js
@@ -16,9 +16,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/esbuild-plugin-html/lib/collectAssets.js
+++ b/packages/esbuild-plugin-html/lib/collectAssets.js
@@ -17,7 +17,7 @@ export async function collectAsset($, element, attribute, options, helpers) {
 
     const entryPoint = resolvedFile.path;
     const file = await helpers.emitFile(entryPoint);
-    element.attr(attribute, file.path.replace(path.sep, '/'));
+    element.attr(attribute, file.path.split(path.sep).join('/'));
 
     return {
         ...file,

--- a/packages/esbuild-plugin-html/lib/collectAssets.js
+++ b/packages/esbuild-plugin-html/lib/collectAssets.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import { isRelativeUrl } from '@chialab/node-resolve';
 
 /**
@@ -16,7 +17,7 @@ export async function collectAsset($, element, attribute, options, helpers) {
 
     const entryPoint = resolvedFile.path;
     const file = await helpers.emitFile(entryPoint);
-    element.attr(attribute, file.path);
+    element.attr(attribute, file.path.replace(path.sep, '/'));
 
     return {
         ...file,

--- a/packages/esbuild-plugin-html/lib/collectIcons.js
+++ b/packages/esbuild-plugin-html/lib/collectIcons.js
@@ -106,14 +106,14 @@ export async function collectIcon($, element, icon, rel, shortcut, options, help
     if (icon.size === 196 && shortcut) {
         const link = $('<link>');
         link.attr('rel', 'shortcut icon');
-        link.attr('href', file.path);
+        link.attr('href', file.path.replace(path.sep, '/'));
         link.insertBefore(element);
     }
 
     const link = $('<link>');
     link.attr('rel', rel);
     link.attr('sizes', `${icon.size}x${icon.size}`);
-    link.attr('href', file.path);
+    link.attr('href', file.path.replace(path.sep, '/'));
     link.insertBefore(element);
 
     return {

--- a/packages/esbuild-plugin-html/lib/collectIcons.js
+++ b/packages/esbuild-plugin-html/lib/collectIcons.js
@@ -106,14 +106,14 @@ export async function collectIcon($, element, icon, rel, shortcut, options, help
     if (icon.size === 196 && shortcut) {
         const link = $('<link>');
         link.attr('rel', 'shortcut icon');
-        link.attr('href', file.path.replace(path.sep, '/'));
+        link.attr('href', file.path.split(path.sep).join('/'));
         link.insertBefore(element);
     }
 
     const link = $('<link>');
     link.attr('rel', rel);
     link.attr('sizes', `${icon.size}x${icon.size}`);
-    link.attr('href', file.path.replace(path.sep, '/'));
+    link.attr('href', file.path.split(path.sep).join('/'));
     link.insertBefore(element);
 
     return {

--- a/packages/esbuild-plugin-html/lib/collectScreens.js
+++ b/packages/esbuild-plugin-html/lib/collectScreens.js
@@ -90,7 +90,7 @@ export async function collectScreen($, element, screen, options, helpers) {
     const link = $('<link>');
     link.attr('rel', 'apple-touch-startup-image');
     link.attr('media', screen.query);
-    link.attr('href', file.path);
+    link.attr('href', file.path.replace(path.sep, '/'));
     link.insertBefore(element);
 
     return {

--- a/packages/esbuild-plugin-html/lib/collectScreens.js
+++ b/packages/esbuild-plugin-html/lib/collectScreens.js
@@ -90,7 +90,7 @@ export async function collectScreen($, element, screen, options, helpers) {
     const link = $('<link>');
     link.attr('rel', 'apple-touch-startup-image');
     link.attr('media', screen.query);
-    link.attr('href', file.path.replace(path.sep, '/'));
+    link.attr('href', file.path.split(path.sep).join('/'));
     link.insertBefore(element);
 
     return {

--- a/packages/esbuild-plugin-html/lib/collectScripts.js
+++ b/packages/esbuild-plugin-html/lib/collectScripts.js
@@ -81,10 +81,10 @@ async function innerCollect($, dom, elements, target, format, type, attrs = {}, 
         const relativeOutName = path.relative(options.entryDir, fullOutName);
 
         if ($(element).attr('src')) {
-            $(element).attr('src', relativeOutName.replace(path.sep, '/'));
+            $(element).attr('src', relativeOutName.split(path.sep).join('/'));
             $(element).html('');
         } else {
-            $(element).html(`import './${relativeOutName.replace(path.sep, '/')}'`);
+            $(element).html(`import './${relativeOutName.split(path.sep).join('/')}'`);
         }
         $(element).removeAttr('type').attr('type', type);
         for (const attrName in attrs) {
@@ -109,7 +109,7 @@ function loadStyle(url) {
 ${styleFiles.map((outName) => {
             const fullOutFile = path.join(options.workingDir, outName);
             const relativeOutFile = path.relative(options.entryDir, fullOutFile);
-            return `loadStyle('${relativeOutFile.replace(path.sep, '/')}');`;
+            return `loadStyle('${relativeOutFile.split(path.sep).join('/')}');`;
         }).join('\n')}
 }());`);
         dom.find('head').append(script);

--- a/packages/esbuild-plugin-html/lib/collectScripts.js
+++ b/packages/esbuild-plugin-html/lib/collectScripts.js
@@ -81,10 +81,10 @@ async function innerCollect($, dom, elements, target, format, type, attrs = {}, 
         const relativeOutName = path.relative(options.entryDir, fullOutName);
 
         if ($(element).attr('src')) {
-            $(element).attr('src', relativeOutName);
+            $(element).attr('src', relativeOutName.replace(path.sep, '/'));
             $(element).html('');
         } else {
-            $(element).html(`import './${relativeOutName}'`);
+            $(element).html(`import './${relativeOutName.replace(path.sep, '/')}'`);
         }
         $(element).removeAttr('type').attr('type', type);
         for (const attrName in attrs) {
@@ -109,7 +109,7 @@ function loadStyle(url) {
 ${styleFiles.map((outName) => {
             const fullOutFile = path.join(options.workingDir, outName);
             const relativeOutFile = path.relative(options.entryDir, fullOutFile);
-            return `loadStyle('${relativeOutFile}');`;
+            return `loadStyle('${relativeOutFile.replace(path.sep, '/')}');`;
         }).join('\n')}
 }());`);
         dom.find('head').append(script);

--- a/packages/esbuild-plugin-html/lib/collectStyles.js
+++ b/packages/esbuild-plugin-html/lib/collectStyles.js
@@ -73,9 +73,9 @@ export async function collectStyles($, dom, options, helpers) {
         const relativeOutName = path.relative(options.entryDir, fullOutName);
 
         if ($(element).is('link')) {
-            $(element).attr('href', relativeOutName);
+            $(element).attr('href', relativeOutName.replace(path.sep, '/'));
         } else {
-            $(element).html(`@import '${relativeOutName}'`);
+            $(element).html(`@import '${relativeOutName.replace(path.sep, '/')}'`);
         }
     });
 

--- a/packages/esbuild-plugin-html/lib/collectStyles.js
+++ b/packages/esbuild-plugin-html/lib/collectStyles.js
@@ -73,9 +73,9 @@ export async function collectStyles($, dom, options, helpers) {
         const relativeOutName = path.relative(options.entryDir, fullOutName);
 
         if ($(element).is('link')) {
-            $(element).attr('href', relativeOutName.replace(path.sep, '/'));
+            $(element).attr('href', relativeOutName.split(path.sep).join('/'));
         } else {
-            $(element).html(`@import '${relativeOutName.replace(path.sep, '/')}'`);
+            $(element).html(`@import '${relativeOutName.split(path.sep).join('/')}'`);
         }
     });
 

--- a/packages/esbuild-plugin-html/lib/collectWebManifest.js
+++ b/packages/esbuild-plugin-html/lib/collectWebManifest.js
@@ -121,7 +121,7 @@ export async function collectWebManifest($, dom, options, helpers) {
                 const contents = await generateIcon(image, size, 0, { r: 255, g: 255, b: 255, a: 1 });
                 const result = await helpers.emitFile(name, contents);
                 return {
-                    src: path.relative(manifestOutputDir, result.filePath).replace(path.sep, '/'),
+                    src: path.relative(manifestOutputDir, result.filePath).split(path.sep).join('/'),
                     sizes: `${size}x${size}`,
                     type: 'image/png',
                 };
@@ -131,7 +131,7 @@ export async function collectWebManifest($, dom, options, helpers) {
 
     const file = await helpers.emitFile(entryPoint, JSON.stringify(json, null, 2));
 
-    $(element).attr('href', file.path.replace(path.sep, '/'));
+    $(element).attr('href', file.path.split(path.sep).join('/'));
 
     return [{
         ...file,

--- a/packages/esbuild-plugin-html/lib/collectWebManifest.js
+++ b/packages/esbuild-plugin-html/lib/collectWebManifest.js
@@ -121,7 +121,7 @@ export async function collectWebManifest($, dom, options, helpers) {
                 const contents = await generateIcon(image, size, 0, { r: 255, g: 255, b: 255, a: 1 });
                 const result = await helpers.emitFile(name, contents);
                 return {
-                    src: path.relative(manifestOutputDir, result.filePath),
+                    src: path.relative(manifestOutputDir, result.filePath).replace(path.sep, '/'),
                     sizes: `${size}x${size}`,
                     type: 'image/png',
                 };
@@ -131,7 +131,7 @@ export async function collectWebManifest($, dom, options, helpers) {
 
     const file = await helpers.emitFile(entryPoint, JSON.stringify(json, null, 2));
 
-    $(element).attr('href', file.path);
+    $(element).attr('href', file.path.replace(path.sep, '/'));
 
     return [{
         ...file,

--- a/packages/esbuild-plugin-html/test/test.spec.js
+++ b/packages/esbuild-plugin-html/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import htmlPlugin from '@chialab/esbuild-plugin-html';
 import virtualPlugin from '@chialab/esbuild-plugin-virtual';
@@ -6,8 +7,8 @@ import { expect } from 'chai';
 describe('esbuild-plugin-html', () => {
     it('should bundle webapp with scripts', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.iife.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.iife.html', import.meta.url))],
             sourceRoot: '/',
             chunkNames: '[name]-[hash]',
             outdir: 'out',
@@ -76,8 +77,8 @@ body {
 
     it('should bundle webapp with scripts and sourcemaps', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.iife.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.iife.html', import.meta.url))],
             sourceRoot: '/',
             chunkNames: '[name]-[hash]',
             outdir: 'out',
@@ -149,8 +150,8 @@ body {
 
     it('should bundle webapp with modules', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.esm.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.esm.html', import.meta.url))],
             sourceRoot: '/',
             chunkNames: '[name]-[hash]',
             outdir: 'out',
@@ -242,8 +243,8 @@ body {
 
     it('should bundle webapp with modules and chunks', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.chunks.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.chunks.html', import.meta.url))],
             sourceRoot: '/',
             chunkNames: '[name]-[hash]',
             outdir: 'out',
@@ -344,8 +345,8 @@ body {
 
     it('should bundle webapp with modules and scripts', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.mixed.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.mixed.html', import.meta.url))],
             sourceRoot: '/',
             chunkNames: '[name]-[hash]',
             outdir: 'out',
@@ -439,8 +440,8 @@ body {
 
     it('should bundle webapp with styles', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.css.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.css.html', import.meta.url))],
             sourceRoot: '/',
             chunkNames: '[name]-[hash]',
             outdir: 'out',
@@ -496,9 +497,9 @@ body {
 
     it('should bundle webapp with virtual styles', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('./index.html', import.meta.url).pathname],
-            sourceRoot: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('./index.html', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('.', import.meta.url)),
             chunkNames: '[name]-[hash]',
             outdir: 'out',
             bundle: true,
@@ -506,7 +507,7 @@ body {
             plugins: [
                 virtualPlugin([
                     {
-                        path: new URL('./index.html', import.meta.url).pathname,
+                        path: fileURLToPath(new URL('./index.html', import.meta.url)),
                         contents: `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -570,8 +571,8 @@ html {
 
     it('should bundle webapp with png favicons', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.icons.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.icons.html', import.meta.url))],
             sourceRoot: '/',
             assetNames: 'icons/[name]',
             outdir: 'out',
@@ -619,8 +620,8 @@ html {
 
     it('should bundle webapp with svg favicon', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.svgicons.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.svgicons.html', import.meta.url))],
             sourceRoot: '/',
             assetNames: 'icons/[name]',
             outdir: 'out',
@@ -661,8 +662,8 @@ html {
         this.timeout(15000);
 
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.screens.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.screens.html', import.meta.url))],
             sourceRoot: '/',
             assetNames: 'screens/[name]',
             outdir: 'out',
@@ -710,8 +711,8 @@ html {
 
     it('should bundle webapp with assets', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.assets.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.assets.html', import.meta.url))],
             sourceRoot: '/',
             assetNames: 'assets/[dir]/[name]',
             outdir: 'out',
@@ -756,8 +757,8 @@ html {
 
     it('should bundle webapp with a webmanifest', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.manifest.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.manifest.html', import.meta.url))],
             sourceRoot: '/',
             assetNames: 'assets/[name]',
             outdir: 'out',
@@ -868,10 +869,10 @@ html {
 
     it('should bundle webapp with [dir] and outbase', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.iife.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.iife.html', import.meta.url))],
             sourceRoot: '/',
-            outbase: new URL('./', import.meta.url).pathname,
+            outbase: fileURLToPath(new URL('./', import.meta.url)),
             entryNames: '[dir]/[name]',
             chunkNames: '[name]',
             outdir: 'out',
@@ -922,8 +923,8 @@ html {
 
     it('should bundle webapp with [dir] without outbase', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/index.iife.html', import.meta.url).pathname],
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.iife.html', import.meta.url))],
             sourceRoot: '/',
             entryNames: '[dir]/[name]',
             chunkNames: '[name]',

--- a/packages/esbuild-plugin-html/test/test.spec.js
+++ b/packages/esbuild-plugin-html/test/test.spec.js
@@ -1,8 +1,12 @@
+import path from 'path';
 import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import htmlPlugin from '@chialab/esbuild-plugin-html';
 import virtualPlugin from '@chialab/esbuild-plugin-virtual';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiString from 'chai-string';
+
+chai.use(chaiString);
 
 describe('esbuild-plugin-html', () => {
     it('should bundle webapp with scripts', async () => {
@@ -24,7 +28,7 @@ describe('esbuild-plugin-html', () => {
 
         expect(outputFiles).to.have.lengthOf(3);
 
-        expect(index.path.endsWith('/out/index.iife.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.iife.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -52,7 +56,7 @@ describe('esbuild-plugin-html', () => {
 
 </html>`);
 
-        expect(js.path.endsWith('/out/index-JEYWDNLH.js')).to.be.true;
+        expect(js.path).endsWith(path.join(path.sep, 'out', 'index-JEYWDNLH.js'));
         expect(js.text).to.be.equal(`"use strict";
 (() => {
   // fixture/lib.js
@@ -65,7 +69,7 @@ describe('esbuild-plugin-html', () => {
 })();
 `);
 
-        expect(css.path.endsWith('/out/index-UMVLUHQU.css')).to.be.true;
+        expect(css.path).endsWith(path.join(path.sep, 'out', 'index-UMVLUHQU.css'));
         expect(css.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
@@ -95,7 +99,7 @@ body {
 
         expect(outputFiles).to.have.lengthOf(5);
 
-        expect(index.path.endsWith('/out/index.iife.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.iife.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -123,7 +127,7 @@ body {
 
 </html>`);
 
-        expect(js.path.endsWith('/out/index-FIAOTJ3G.js')).to.be.true;
+        expect(js.path).endsWith(path.join(path.sep, 'out', 'index-FIAOTJ3G.js'));
         expect(js.text).to.be.equal(`"use strict";
 (() => {
   // fixture/lib.js
@@ -137,7 +141,7 @@ body {
 //# sourceMappingURL=index-FIAOTJ3G.js.map
 `);
 
-        expect(css.path.endsWith('/out/index-CECUKMCO.css')).to.be.true;
+        expect(css.path).endsWith(path.join(path.sep, 'out', 'index-CECUKMCO.css'));
         expect(css.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
@@ -164,14 +168,14 @@ body {
         });
 
         const [index, ...files] = outputFiles;
-        const jsFile = files.find((file) => file.path.includes('/out/index') && file.path.endsWith('.js'));
-        const jsSource = files.find((file) => file.path.includes('/out/1-') && file.path.endsWith('.js'));
-        const jsChunk = files.find((file) => file.path.includes('/out/chunk-') && file.path.endsWith('.js'));
+        const jsFile = files.find((file) => file.path.includes(path.join(path.sep, 'out', 'index')) && file.path.endsWith('.js'));
+        const jsSource = files.find((file) => file.path.includes(path.join(path.sep, 'out', '1-')) && file.path.endsWith('.js'));
+        const jsChunk = files.find((file) => file.path.includes(path.join(path.sep, 'out', 'chunk-')) && file.path.endsWith('.js'));
         const css = files.find((file) => file.path.endsWith('.css'));
 
         expect(outputFiles).to.have.lengthOf(5);
 
-        expect(index.path.endsWith('/out/index.esm.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.esm.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -202,7 +206,7 @@ body {
 
 </html>`);
 
-        expect(jsFile.path.endsWith('index-7DQE4SCR.js')).to.be.true;
+        expect(path.basename(jsFile.path)).endsWith('index-7DQE4SCR.js');
         expect(jsFile.text).to.be.equal(`import {
   log
 } from "./chunk-VLQWHBZB.js";
@@ -213,7 +217,7 @@ window.addEventListener("load", () => {
 });
 `);
 
-        expect(jsSource.path.endsWith('/1-ZOQZ7JHL.js')).to.be.true;
+        expect(path.basename(jsSource.path)).endsWith('1-ZOQZ7JHL.js');
         expect(jsSource.text).to.be.equal(`import {
   log
 } from "./chunk-VLQWHBZB.js";
@@ -222,7 +226,7 @@ window.addEventListener("load", () => {
 log("test");
 `);
 
-        expect(jsChunk.path.endsWith('/chunk-VLQWHBZB.js')).to.be.true;
+        expect(path.basename(jsChunk.path)).endsWith('chunk-VLQWHBZB.js');
         expect(jsChunk.text).to.be.equal(`// fixture/lib.js
 var log = console.log.bind(console);
 
@@ -231,7 +235,7 @@ export {
 };
 `);
 
-        expect(css.path.endsWith('/index-UMVLUHQU.css')).to.be.true;
+        expect(path.basename(css.path)).endsWith('index-UMVLUHQU.css');
         expect(css.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
@@ -258,15 +262,15 @@ body {
         });
 
         const [index, ...files] = outputFiles;
-        const jsFile = files.find((file) => file.path.includes('/out/index') && file.path.endsWith('.js'));
-        const jsSource = files.find((file) => file.path.includes('/out/1-') && file.path.endsWith('.js'));
-        const jsLib = files.find((file) => file.path.includes('/out/lib-') && file.path.endsWith('.js'));
-        const jsChunk = files.find((file) => file.path.includes('/out/chunk-') && file.path.endsWith('.js'));
+        const jsFile = files.find((file) => file.path.includes(path.join(path.sep, 'out', 'index')) && file.path.endsWith('.js'));
+        const jsSource = files.find((file) => file.path.includes(path.join(path.sep, 'out', '1-')) && file.path.endsWith('.js'));
+        const jsLib = files.find((file) => file.path.includes(path.join(path.sep, 'out', 'lib-')) && file.path.endsWith('.js'));
+        const jsChunk = files.find((file) => file.path.includes(path.join(path.sep, 'out', 'chunk-')) && file.path.endsWith('.js'));
         const css = files.find((file) => file.path.endsWith('.css'));
 
         expect(outputFiles).to.have.lengthOf(6);
 
-        expect(index.path.endsWith('/out/index.chunks.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.chunks.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -297,7 +301,7 @@ body {
 
 </html>`);
 
-        expect(jsFile.path.endsWith('/index-NISLXZJK.js')).to.be.true;
+        expect(path.basename(jsFile.path)).endsWith('index-NISLXZJK.js');
         expect(jsFile.text).to.be.equal(`import {
   log
 } from "./chunk-GNFD7QL2.js";
@@ -308,14 +312,14 @@ window.addEventListener("load", () => {
 });
 `);
 
-        expect(jsSource.path.endsWith('/1-GWHRC5DW.js')).to.be.true;
+        expect(path.basename(jsSource.path)).endsWith('1-GWHRC5DW.js');
         expect(jsSource.text).to.be.equal(`// fixture/1.js
 import("./lib-476DRX7L.js").then(({ log }) => {
   log("test");
 });
 `);
 
-        expect(jsLib.path.endsWith('/lib-476DRX7L.js')).to.be.true;
+        expect(path.basename(jsLib.path)).endsWith('lib-476DRX7L.js');
         expect(jsLib.text).to.be.equal(`import {
   log
 } from "./chunk-GNFD7QL2.js";
@@ -324,7 +328,7 @@ export {
 };
 `);
 
-        expect(jsChunk.path.endsWith('/chunk-GNFD7QL2.js')).to.be.true;
+        expect(path.basename(jsChunk.path)).endsWith('chunk-GNFD7QL2.js');
         expect(jsChunk.text).to.be.equal(`// fixture/lib.js
 var log = console.log.bind(console);
 
@@ -333,7 +337,7 @@ export {
 };
 `);
 
-        expect(css.path.endsWith('/index-UMVLUHQU.css')).to.be.true;
+        expect(path.basename(css.path)).endsWith('index-UMVLUHQU.css');
         expect(css.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
@@ -365,7 +369,7 @@ body {
 
         expect(outputFiles).to.have.lengthOf(5);
 
-        expect(index.path.endsWith('/out/index.mixed.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.mixed.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -405,7 +409,7 @@ body {
 
 </html>`);
 
-        expect(iife.path.endsWith('/out/index-JEYWDNLH.js')).to.be.true;
+        expect(iife.path).endsWith(path.join(path.sep, 'out', 'index-JEYWDNLH.js'));
         expect(iife.text).to.be.equal(`"use strict";
 (() => {
   // fixture/lib.js
@@ -418,7 +422,7 @@ body {
 })();
 `);
 
-        expect(esm.path.endsWith('/out/index-6PRLBFYO.js')).to.be.true;
+        expect(esm.path).endsWith(path.join(path.sep, 'out', 'index-6PRLBFYO.js'));
         expect(esm.text).to.be.equal(`// fixture/lib.js
 var log = console.log.bind(console);
 
@@ -428,7 +432,7 @@ window.addEventListener("load", () => {
 });
 `);
 
-        expect(css.path.endsWith('/out/index-UMVLUHQU.css')).to.be.true;
+        expect(css.path).endsWith(path.join(path.sep, 'out', 'index-UMVLUHQU.css'));
         expect(css.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
@@ -453,12 +457,12 @@ body {
         });
 
         const [index, ...cssFiles] = outputFiles;
-        const cssFile = cssFiles.find((output) => output.path.includes('/out/index'));
-        const cssSource = cssFiles.find((output) => output.path.includes('/out/1-'));
+        const cssFile = cssFiles.find((output) => output.path.includes(path.join(path.sep, 'out', 'index')));
+        const cssSource = cssFiles.find((output) => output.path.includes(path.join(path.sep, 'out', '1-')));
 
         expect(outputFiles).to.have.lengthOf(3);
 
-        expect(index.path.endsWith('/out/index.css.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.css.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -478,7 +482,7 @@ body {
 
 </html>`);
 
-        expect(cssFile.path.endsWith('/out/index-UMVLUHQU.css')).to.be.true;
+        expect(cssFile.path).endsWith(path.join(path.sep, 'out', 'index-UMVLUHQU.css'));
         expect(cssFile.text).to.be.equal(`/* fixture/index.css */
 html,
 body {
@@ -487,7 +491,7 @@ body {
 }
 `);
 
-        expect(cssSource.path.endsWith('/out/1-EKADEBHI.css')).to.be.true;
+        expect(cssSource.path).endsWith(path.join(path.sep, 'out', '1-EKADEBHI.css'));
         expect(cssSource.text).to.be.equal(`/* fixture/1.css */
 body {
   color: red;
@@ -542,7 +546,7 @@ body {
 
         expect(outputFiles).to.have.lengthOf(2);
 
-        expect(index.path.endsWith('/out/index.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -559,7 +563,7 @@ body {
 
 </html>`);
 
-        expect(css.path.endsWith('/out/index-JHCCFNW4.css')).to.be.true;
+        expect(css.path).endsWith(path.join(path.sep, 'out', 'index-JHCCFNW4.css'));
         expect(css.text).to.be.equal(`/* lib.css */
 html {
   padding: 0;
@@ -588,7 +592,7 @@ html {
 
         expect(outputFiles).to.have.lengthOf(7);
 
-        expect(index.path.endsWith('/out/index.icons.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.icons.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -611,10 +615,10 @@ html {
 
 </html>`);
 
-        expect(icons[0].path.endsWith('/out/icons/favicon-16x16.png')).to.be.true;
+        expect(icons[0].path).endsWith(path.join(path.sep, 'out', 'icons', 'favicon-16x16.png'));
         expect(icons[0].contents.byteLength).to.be.equal(459);
 
-        expect(icons[3].path.endsWith('/out/icons/favicon-196x196.png')).to.be.true;
+        expect(icons[3].path).endsWith(path.join(path.sep, 'out', 'icons', 'favicon-196x196.png'));
         expect(icons[3].contents.byteLength).to.be.equal(6366);
     });
 
@@ -637,7 +641,7 @@ html {
 
         expect(outputFiles).to.have.lengthOf(2);
 
-        expect(index.path.endsWith('/out/index.svgicons.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.svgicons.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -654,7 +658,7 @@ html {
 
 </html>`);
 
-        expect(icon.path.endsWith('/out/icons/icon.svg')).to.be.true;
+        expect(icon.path).endsWith(path.join(path.sep, 'out', 'icons', 'icon.svg'));
         expect(icon.contents.byteLength).to.be.equal(1475);
     });
 
@@ -679,7 +683,7 @@ html {
 
         expect(outputFiles).to.have.lengthOf(8);
 
-        expect(index.path.endsWith('/out/index.screens.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.screens.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -702,10 +706,10 @@ html {
 
 </html>`);
 
-        expect(screens[0].path.endsWith('/out/screens/apple-launch-iphonex.png')).to.be.true;
+        expect(screens[0].path).endsWith(path.join(path.sep, 'out', 'screens', 'apple-launch-iphonex.png'));
         expect(screens[0].contents.byteLength).to.be.equal(21254);
 
-        expect(screens[3].path.endsWith('/out/screens/apple-launch-iphone5.png')).to.be.true;
+        expect(screens[3].path).endsWith(path.join(path.sep, 'out', 'screens', 'apple-launch-iphone5.png'));
         expect(screens[3].contents.byteLength).to.be.equal(8536);
     });
 
@@ -728,7 +732,7 @@ html {
 
         expect(outputFiles).to.have.lengthOf(3);
 
-        expect(index.path.endsWith('/out/index.assets.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.assets.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -748,10 +752,10 @@ html {
 
         assets.sort((a1, a2) => a2.contents.byteLength - a1.contents.byteLength);
 
-        expect(assets[0].path.endsWith('/out/assets/img/icon.png')).to.be.true;
+        expect(assets[0].path).endsWith(path.join(path.sep, 'out', 'assets', 'img', 'icon.png'));
         expect(assets[0].contents.byteLength).to.be.equal(20754);
 
-        expect(assets[1].path.endsWith('/out/assets/icon.svg')).to.be.true;
+        expect(assets[1].path).endsWith(path.join(path.sep, 'out', 'assets', 'icon.svg'));
         expect(assets[1].contents.byteLength).to.be.equal(1475);
     });
 
@@ -776,7 +780,7 @@ html {
 
         expect(outputFiles).to.have.lengthOf(17);
 
-        expect(index.path.endsWith('/out/index.manifest.html')).to.be.true;
+        expect(index.path).endsWith('/out/index.manifest.html');
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -802,12 +806,12 @@ html {
 </html>`);
 
         expect(icons).to.have.lengthOf(9);
-        expect(icons[0].path.endsWith('/out/assets/android-chrome-36x36.png')).to.be.true;
+        expect(icons[0].path).endsWith('/out/assets/android-chrome-36x36.png');
         expect(icons[0].contents.byteLength).to.be.equal(1135);
-        expect(icons[8].path.endsWith('/out/assets/android-chrome-512x512.png')).to.be.true;
+        expect(icons[8].path).endsWith('/out/assets/android-chrome-512x512.png');
         expect(icons[8].contents.byteLength).to.be.equal(24012);
 
-        expect(manifest.path.endsWith('/out/assets/manifest.webmanifest')).to.be.true;
+        expect(manifest.path).endsWith('/out/assets/manifest.webmanifest');
         expect(manifest.text).to.be.equal(`{
   "name": "Document",
   "short_name": "Document",
@@ -889,7 +893,7 @@ html {
         const css = files.find((file) => file.path.endsWith('.css'));
 
         expect(outputFiles).to.have.lengthOf(3);
-        expect(index.path.endsWith('/out/fixture/index.iife.html')).to.be.true;
+        expect(index.path).endsWith('/out/fixture/index.iife.html');
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -917,8 +921,8 @@ html {
 
 </html>`);
 
-        expect(js.path.endsWith('/out/index.js')).to.be.true;
-        expect(css.path.endsWith('/out/index.css')).to.be.true;
+        expect(js.path).endsWith('/out/index.js');
+        expect(css.path).endsWith('/out/index.css');
     });
 
     it('should bundle webapp with [dir] without outbase', async () => {
@@ -942,7 +946,7 @@ html {
         const css = files.find((file) => file.path.endsWith('.css'));
 
         expect(outputFiles).to.have.lengthOf(3);
-        expect(index.path.endsWith('/out/index.iife.html')).to.be.true;
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.iife.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -970,7 +974,7 @@ html {
 
 </html>`);
 
-        expect(js.path.endsWith('/out/index.js')).to.be.true;
-        expect(css.path.endsWith('/out/index.css')).to.be.true;
+        expect(js.path).endsWith('/out/index.js');
+        expect(css.path).endsWith('/out/index.css');
     });
 });

--- a/packages/esbuild-plugin-html/test/test.spec.js
+++ b/packages/esbuild-plugin-html/test/test.spec.js
@@ -780,7 +780,7 @@ html {
 
         expect(outputFiles).to.have.lengthOf(17);
 
-        expect(index.path).endsWith('/out/index.manifest.html');
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.manifest.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -806,12 +806,12 @@ html {
 </html>`);
 
         expect(icons).to.have.lengthOf(9);
-        expect(icons[0].path).endsWith('/out/assets/android-chrome-36x36.png');
+        expect(icons[0].path).endsWith(path.join(path.sep, 'out', 'assets', 'android-chrome-36x36.png'));
         expect(icons[0].contents.byteLength).to.be.equal(1135);
-        expect(icons[8].path).endsWith('/out/assets/android-chrome-512x512.png');
+        expect(icons[8].path).endsWith(path.join(path.sep, 'out', 'assets', 'android-chrome-512x512.png'));
         expect(icons[8].contents.byteLength).to.be.equal(24012);
 
-        expect(manifest.path).endsWith('/out/assets/manifest.webmanifest');
+        expect(manifest.path).endsWith(path.join(path.sep, 'out', 'assets', 'manifest.webmanifest'));
         expect(manifest.text).to.be.equal(`{
   "name": "Document",
   "short_name": "Document",
@@ -893,7 +893,7 @@ html {
         const css = files.find((file) => file.path.endsWith('.css'));
 
         expect(outputFiles).to.have.lengthOf(3);
-        expect(index.path).endsWith('/out/fixture/index.iife.html');
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'fixture', 'index.iife.html'));
         expect(index.text).to.be.equal(`<!DOCTYPE html>
 <html lang="en">
 
@@ -921,8 +921,8 @@ html {
 
 </html>`);
 
-        expect(js.path).endsWith('/out/index.js');
-        expect(css.path).endsWith('/out/index.css');
+        expect(js.path).endsWith(path.join(path.sep, 'out', 'index.js'));
+        expect(css.path).endsWith(path.join(path.sep, 'out', 'index.css'));
     });
 
     it('should bundle webapp with [dir] without outbase', async () => {
@@ -974,7 +974,7 @@ html {
 
 </html>`);
 
-        expect(js.path).endsWith('/out/index.js');
-        expect(css.path).endsWith('/out/index.css');
+        expect(js.path).endsWith(path.join(path.sep, 'out', 'index.js'));
+        expect(css.path).endsWith(path.join(path.sep, 'out', 'index.css'));
     });
 });

--- a/packages/esbuild-plugin-meta-url/test/test.spec.js
+++ b/packages/esbuild-plugin-meta-url/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import path from 'path';
 import esbuild from 'esbuild';
 import metaUrl from '@chialab/esbuild-plugin-meta-url';
@@ -7,10 +8,10 @@ import { expect } from 'chai';
 describe('esbuild-plugin-meta-url', () => {
     it('should load a file', async () => {
         const { outputFiles: [result, file] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const file = new URL(\'./file.txt\', import.meta.url);',
             },
             format: 'esm',
@@ -37,10 +38,10 @@ export {
 
     it('should load a file that was part of another build', async () => {
         const { outputFiles: [result, file] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export * from \'./file1.js\';export * from \'./file2.js\';',
             },
             assetNames: '[name]-[hash]',
@@ -84,10 +85,10 @@ export {
 
     it('should search for non literal references', async () => {
         const { outputFiles: [result, file] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `const fileName = './file.txt';
 export const file = new URL(fileName, import.meta.url);`,
             },
@@ -113,10 +114,10 @@ export {
 
     it('should skip unknown references', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const file = new URL(globalThis.test, import.meta.url);',
             },
             format: 'esm',
@@ -138,10 +139,10 @@ export {
 
     it('should use browser base url for iife', async () => {
         const { outputFiles: [result, file] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const file = new URL(\'./file.txt\', import.meta.url);',
             },
             platform: 'browser',
@@ -169,10 +170,10 @@ export {
 
     it('should use node legacy file path', async () => {
         const { outputFiles: [result, file] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const file = new URL(\'./file.txt\', import.meta.url);',
             },
             platform: 'node',
@@ -224,10 +225,10 @@ var file = new URL("./file.txt?hash=4e1243bd", "file://" + __filename);
 
     it('should resolve a module with warnings', async () => {
         const { warnings, outputFiles: [result, file] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const file = new URL(\'npm_module\', import.meta.url);',
             },
             format: 'esm',
@@ -277,10 +278,10 @@ export {
 
     it('should not resolve a module with warnings', async () => {
         const { warnings, outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const file = new URL(\'./missing.txt\', import.meta.url);',
             },
             format: 'esm',

--- a/packages/esbuild-plugin-postcss/test/test.spec.js
+++ b/packages/esbuild-plugin-postcss/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import postcssPlugin from '@chialab/esbuild-plugin-postcss';
 import { expect } from 'chai';
@@ -5,9 +6,9 @@ import { expect } from 'chai';
 describe('esbuild-plugin-postcss', () => {
     it('should run postcss default transformations', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                sourcefile: new URL('input.css', import.meta.url).pathname,
+                sourcefile: fileURLToPath(new URL('input.css', import.meta.url)),
                 contents: `::placeholder {
   color: gray;
 }`,
@@ -43,9 +44,9 @@ describe('esbuild-plugin-postcss', () => {
 
     it('should convert sass', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                sourcefile: new URL('input.scss', import.meta.url).pathname,
+                sourcefile: fileURLToPath(new URL('input.scss', import.meta.url)),
                 contents: `.parent {
   .child {
     color: red;
@@ -74,9 +75,9 @@ describe('esbuild-plugin-postcss', () => {
 
     it('should include sass modules', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.scss', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.scss', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             loader: {
                 '.scss': 'css',
             },
@@ -103,9 +104,9 @@ html {
 
     it('should load postcss config', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.css', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.css', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             format: 'esm',
             target: 'esnext',
             bundle: true,

--- a/packages/esbuild-plugin-unwebpack/test/test.spec.js
+++ b/packages/esbuild-plugin-unwebpack/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import unwebpackPlugin from '@chialab/esbuild-plugin-unwebpack';
 import { expect } from 'chai';
@@ -5,9 +6,9 @@ import { expect } from 'chai';
 describe('esbuild-plugin-unwebpack', () => {
     it('should replace hmr statements', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                sourcefile: new URL(import.meta.url).pathname,
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `export const test = {};
 if (module.hot) {
   module.hot.accept();
@@ -44,9 +45,9 @@ export {
 
     it('should resolve magic imports', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
-            entryPoints: [new URL('fixture/input.js', import.meta.url).pathname],
-            sourceRoot: new URL('fixture', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/input.js', import.meta.url))],
+            sourceRoot: fileURLToPath(new URL('fixture', import.meta.url)),
             outdir: 'fixture/output',
             format: 'esm',
             target: 'esnext',

--- a/packages/esbuild-plugin-virtual/test/test.spec.js
+++ b/packages/esbuild-plugin-virtual/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import virtualPlugin, { createVirtualPlugin } from '@chialab/esbuild-plugin-virtual';
 import { expect } from 'chai';
@@ -6,7 +7,7 @@ describe('esbuild-plugin-virtual', () => {
     it('should load virtual modules', async () => {
         const { outputFiles: [result] } = await esbuild.build({
             stdin: {
-                sourcefile: new URL(import.meta.url).pathname,
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `import { test } from 'virtualMod';
 export { test }`,
             },
@@ -37,7 +38,7 @@ export {
     it('should load virtual modules with a new plugin instance', async () => {
         const { outputFiles: [result] } = await esbuild.build({
             stdin: {
-                sourcefile: new URL(import.meta.url).pathname,
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `import { test } from 'virtualMod';
 export { test }`,
             },
@@ -68,7 +69,7 @@ export {
     it('should load css virtual modules', async () => {
         const { outputFiles: [result] } = await esbuild.build({
             stdin: {
-                sourcefile: new URL(import.meta.url).pathname,
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: '@import \'virtualMod\';',
                 loader: 'css',
             },

--- a/packages/esbuild-plugin-worker/test/test.spec.js
+++ b/packages/esbuild-plugin-worker/test/test.spec.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import path from 'path';
 import esbuild from 'esbuild';
 import workerPlugin from '@chialab/esbuild-plugin-worker';
@@ -6,10 +7,10 @@ import { expect } from 'chai';
 describe('esbuild-plugin-worker', () => {
     it('should load a classic worker with bundle', async () => {
         const { outputFiles: [result, worker] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const worker = new Worker(\'./worker.js\');',
             },
             format: 'esm',
@@ -41,10 +42,10 @@ export {
 
     it('should load a classic worker without bundle', async () => {
         const { outputFiles: [result, worker] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const worker = new Worker(\'./worker.js\');',
             },
             format: 'esm',
@@ -75,10 +76,10 @@ export {
 
     it('should load a module worker with bundle', async () => {
         const { outputFiles: [result, worker] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const worker = new Worker(\'./worker.js\', { type: "module" });',
             },
             format: 'esm',
@@ -107,10 +108,10 @@ postMessage("message");
 
     it('should load a module worker without bundle', async () => {
         const { outputFiles } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const worker = new Worker(\'./worker.js\', { type: "module" });',
             },
             format: 'esm',
@@ -137,10 +138,10 @@ postMessage("message");
 
     it('should proxy a worker request', async () => {
         const { outputFiles: [result, worker] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const worker = new Worker(\'./worker.js\');',
             },
             format: 'esm',
@@ -176,10 +177,10 @@ export {
 
     it('should proxy an unknown worker request', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: 'export const worker = new Worker(workerName);',
             },
             format: 'esm',
@@ -205,10 +206,10 @@ export {
 
     it('should skip unknown worker class', async () => {
         const { outputFiles: [result] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `export const worker = new Worker('./worker.js');
 export const fakeWorker = new ctx.Worker('./worker.js');`,
             },
@@ -233,10 +234,10 @@ export {
 
     it('should detect local Worker definitions', async () => {
         const { outputFiles: [result, worker] } = await esbuild.build({
-            absWorkingDir: new URL('.', import.meta.url).pathname,
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
             stdin: {
-                resolveDir: new URL('.', import.meta.url).pathname,
-                sourcefile: new URL(import.meta.url).pathname,
+                resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+                sourcefile: fileURLToPath(import.meta.url),
                 contents: `class Worker {};
 export const local = new Worker('./worker.js');
 export const worker = new window.Worker('./worker.js');`,

--- a/packages/estransform/build.js
+++ b/packages/estransform/build.js
@@ -15,9 +15,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/node-resolve/build.js
+++ b/packages/node-resolve/build.js
@@ -15,9 +15,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/rna-dev-server/build.js
+++ b/packages/rna-dev-server/build.js
@@ -24,9 +24,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/rna-logger/build.js
+++ b/packages/rna-logger/build.js
@@ -12,9 +12,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/rna-storybook/build.js
+++ b/packages/rna-storybook/build.js
@@ -24,9 +24,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/rna-storybook/lib/templates.js
+++ b/packages/rna-storybook/lib/templates.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url';
 import { readFile } from 'fs/promises';
 import _ from 'lodash';
 
@@ -14,7 +15,7 @@ async function template(filePath, data) {
  * @param {*} data
  * @param {string} [file]
  */
-export function indexHtml(data, file = new URL('../static/index.html', import.meta.url).pathname) {
+export function indexHtml(data, file = fileURLToPath(new URL('../static/index.html', import.meta.url))) {
     return template(file, data);
 }
 
@@ -22,20 +23,20 @@ export function indexHtml(data, file = new URL('../static/index.html', import.me
  * @param {*} data
  * @param {string} [file]
  */
-export function iframeHtml(data, file = new URL('../static/iframe.html', import.meta.url).pathname) {
+export function iframeHtml(data, file = fileURLToPath(new URL('../static/iframe.html', import.meta.url))) {
     return template(file, data);
 }
 
 /**
  * @param {string} [file]
  */
-export function managerCss(file = new URL('../static/manager.css', import.meta.url).pathname) {
+export function managerCss(file = fileURLToPath(new URL('../static/manager.css', import.meta.url))) {
     return readFile(file, 'utf-8');
 }
 
 /**
  * @param {string} [file]
  */
-export function previewCss(file = new URL('../static/preview.css', import.meta.url).pathname) {
+export function previewCss(file = fileURLToPath(new URL('../static/preview.css', import.meta.url))) {
     return readFile(file, 'utf-8');
 }

--- a/packages/rna-storybook/static/index.html
+++ b/packages/rna-storybook/static/index.html
@@ -9,12 +9,7 @@
     </head>
     <body>
         <div id="root"></div>
-        <script>
-            window['FEATURES'] = {
-                storyStoreV7: true,
-                previewMdx2: true,
-            };
-        </script><% for (var i = 0; i < js.length; i++) { %>
+        <% for (var i = 0; i < js.length; i++) { %>
         <script type="<%= js[i].type %>" src="<%= js[i].path %>"></script><% } %>
     </body>
 </html>

--- a/packages/rna/build.js
+++ b/packages/rna/build.js
@@ -15,9 +15,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/wds-plugin-hmr-dna/build.js
+++ b/packages/wds-plugin-hmr-dna/build.js
@@ -17,9 +17,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/wds-plugin-hmr/build.js
+++ b/packages/wds-plugin-hmr/build.js
@@ -16,9 +16,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/packages/wtr-mocha-reporter/build.js
+++ b/packages/wtr-mocha-reporter/build.js
@@ -17,9 +17,10 @@ esbuild.build({
     banner: {
         js: `import { dirname as __pathDirname } from 'path';
 import { createRequire as __moduleCreateRequire } from 'module';
+import { fileURLToPath as __fileURLToPath  } from 'url';
 
 const require = __moduleCreateRequire(import.meta.url);
-const __filename = new URL(import.meta.url).pathname;
+const __filename = __fileURLToPath(import.meta.url);
 const __dirname = __pathDirname(__filename);
 `,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2044,6 +2044,7 @@ __metadata:
     "@types/chai": ^4.2.22
     "@yarnpkg/core": ^4.0.0-rc.6
     chai: ^4.3.4
+    chai-string: ^1.5.0
     eslint: ^8.0.0
     jsonc-parser: ^3.0.0
     plop: ^2.7.4
@@ -5614,6 +5615,15 @@ __metadata:
   version: 2.0.1
   resolution: "ccount@npm:2.0.1"
   checksum: 48193dada54c9e260e0acf57fc16171a225305548f9ad20d5471e0f7a8c026aedd8747091dccb0d900cde7df4e4ddbd235df0d8de4a64c71b12f0d3303eeafd4
+  languageName: node
+  linkType: hard
+
+"chai-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "chai-string@npm:1.5.0"
+  peerDependencies:
+    chai: ^4.1.2
+  checksum: d443bb416f6d4dd3395442f459af197aff93f2546dcb5bce6313badf505aa828615117f0eadc99e97ec518b7d2df387b538c81c647e6daf5c386d5bafa212e8f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`esbuild-plugin-html` (and other plugins in general) should convert Windows paths (which use `\\` separators) to forward slash urls.

Should fix #118 