### PR TITLE
feat: [esbuild-plugin-html] support publicPath

### DIFF
--- a/packages/esbuild-plugin-html/lib/collectAssets.js
+++ b/packages/esbuild-plugin-html/lib/collectAssets.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import { isRelativeUrl } from '@chialab/node-resolve';
 
 /**
@@ -17,7 +16,8 @@ export async function collectAsset($, element, attribute, options, helpers) {
 
     const entryPoint = resolvedFile.path;
     const file = await helpers.emitFile(entryPoint);
-    element.attr(attribute, file.path.split(path.sep).join('/'));
+    const { publicPath } = helpers.resolvePath(file.path);
+    element.attr(attribute, publicPath);
 
     return {
         ...file,

--- a/packages/esbuild-plugin-html/lib/collectIcons.js
+++ b/packages/esbuild-plugin-html/lib/collectIcons.js
@@ -102,18 +102,19 @@ async function generateAppleIcons(image, icons) {
 export async function collectIcon($, element, icon, rel, shortcut, options, helpers) {
     const entryPoint = path.join(options.sourceDir, icon.name);
     const file = await helpers.emitFile(entryPoint, icon.contents);
+    const { publicPath } = helpers.resolvePath(file.path);
 
     if (icon.size === 196 && shortcut) {
         const link = $('<link>');
         link.attr('rel', 'shortcut icon');
-        link.attr('href', file.path.split(path.sep).join('/'));
+        link.attr('href', publicPath);
         link.insertBefore(element);
     }
 
     const link = $('<link>');
     link.attr('rel', rel);
     link.attr('sizes', `${icon.size}x${icon.size}`);
-    link.attr('href', file.path.split(path.sep).join('/'));
+    link.attr('href', publicPath);
     link.insertBefore(element);
 
     return {

--- a/packages/esbuild-plugin-html/lib/collectScreens.js
+++ b/packages/esbuild-plugin-html/lib/collectScreens.js
@@ -86,11 +86,12 @@ async function generateAppleLaunchScreens(image, launchScreens) {
 export async function collectScreen($, element, screen, options, helpers) {
     const entryPoint = path.join(options.sourceDir, screen.name);
     const file = await helpers.emitFile(entryPoint, screen.contents);
+    const { publicPath } = helpers.resolvePath(file.path)
 
     const link = $('<link>');
     link.attr('rel', 'apple-touch-startup-image');
     link.attr('media', screen.query);
-    link.attr('href', file.path.split(path.sep).join('/'));
+    link.attr('href', publicPath);
     link.insertBefore(element);
 
     return {

--- a/packages/esbuild-plugin-html/lib/collectScripts.js
+++ b/packages/esbuild-plugin-html/lib/collectScripts.js
@@ -79,12 +79,13 @@ async function innerCollect($, dom, elements, target, format, type, attrs = {}, 
 
         const fullOutName = path.join(options.workingDir, outName);
         const relativeOutName = path.relative(options.entryDir, fullOutName);
+        const { relativePath, publicPath } = helpers.resolvePath(relativeOutName);
 
         if ($(element).attr('src')) {
-            $(element).attr('src', relativeOutName.split(path.sep).join('/'));
+            $(element).attr('src', publicPath);
             $(element).html('');
         } else {
-            $(element).html(`import './${relativeOutName.split(path.sep).join('/')}'`);
+            $(element).html(`import './${relativePath}'`);
         }
         $(element).removeAttr('type').attr('type', type);
         for (const attrName in attrs) {
@@ -109,7 +110,8 @@ function loadStyle(url) {
 ${styleFiles.map((outName) => {
             const fullOutFile = path.join(options.workingDir, outName);
             const relativeOutFile = path.relative(options.entryDir, fullOutFile);
-            return `loadStyle('${relativeOutFile.split(path.sep).join('/')}');`;
+            const { publicPath } = helpers.resolvePath(relativeOutFile);
+            return `loadStyle('${publicPath}');`;
         }).join('\n')}
 }());`);
         dom.find('head').append(script);

--- a/packages/esbuild-plugin-html/lib/collectStyles.js
+++ b/packages/esbuild-plugin-html/lib/collectStyles.js
@@ -71,11 +71,12 @@ export async function collectStyles($, dom, options, helpers) {
 
         const fullOutName = path.join(options.workingDir, outName);
         const relativeOutName = path.relative(options.entryDir, fullOutName);
+        const { relativePath, publicPath } = helpers.resolvePath(relativeOutName);
 
         if ($(element).is('link')) {
-            $(element).attr('href', relativeOutName.split(path.sep).join('/'));
+            $(element).attr('href', publicPath);
         } else {
-            $(element).html(`@import '${relativeOutName.split(path.sep).join('/')}'`);
+            $(element).html(`@import '${relativePath}'`);
         }
     });
 

--- a/packages/esbuild-plugin-html/lib/collectWebManifest.js
+++ b/packages/esbuild-plugin-html/lib/collectWebManifest.js
@@ -120,8 +120,12 @@ export async function collectWebManifest($, dom, options, helpers) {
             MANIFEST_ICONS.map(async ({ name, size }) => {
                 const contents = await generateIcon(image, size, 0, { r: 255, g: 255, b: 255, a: 1 });
                 const result = await helpers.emitFile(name, contents);
+
+                const relativeOutName = path.relative(manifestOutputDir, result.filePath);
+                const { publicPath } = helpers.resolvePath(relativeOutName);
+
                 return {
-                    src: path.relative(manifestOutputDir, result.filePath).split(path.sep).join('/'),
+                    src: publicPath,
                     sizes: `${size}x${size}`,
                     type: 'image/png',
                 };
@@ -131,7 +135,9 @@ export async function collectWebManifest($, dom, options, helpers) {
 
     const file = await helpers.emitFile(entryPoint, JSON.stringify(json, null, 2));
 
-    $(element).attr('href', file.path.split(path.sep).join('/'));
+    const { publicPath } = helpers.resolvePath(file.path);
+
+    $(element).attr('href', publicPath);
 
     return [{
         ...file,


### PR DESCRIPTION
Added support for `publicPath` option. See #141 

Not sure if these should be publicPath also 
``` js
// collectScripts.js 88
$(element).html(`import './${relativePath}'`);

// collectStyles.js 79
$(element).html(`@import '${relativePath}'`);
```