### PR TITLE
Update esbuild-plugin-require-resolve/index.js to have kind specified

### DIFF
--- a/packages/esbuild-plugin-require-resolve/lib/index.js
+++ b/packages/esbuild-plugin-require-resolve/lib/index.js
@@ -56,6 +56,7 @@ export default function() {
                         const { path: resolvedFilePath } = await build.resolve(fileName, {
                             importer: args.path,
                             resolveDir: path.dirname(args.path),
+                            kind: 'require-resolve'
                         });
                         if (!resolvedFilePath) {
                             return;


### PR DESCRIPTION
Without this parameter, I'm getting `Must specify "kind" when calling "resolve" ` error for some requires:
![image](https://github.com/chialab/rna/assets/3945692/54af2c00-490a-478b-b8f0-9817d3b9b39c)

Adding kind propertly seems to resolve the issue