### PR TITLE
Resolve relative paths using URL constructor and ignore directories

### DIFF
--- a/.changeset/sweet-radios-pay.md
+++ b/.changeset/sweet-radios-pay.md
@@ -1,0 +1,5 @@
+---
+"@chialab/esbuild-plugin-meta-url": patch
+---
+
+Resolve relative paths using URL constructor and ignore directories.


### PR DESCRIPTION
This PR should fix #164 by changing the way relative paths are resolved. In order to prevent recursion and directories, the plugin now resolves relativa paths using the `URL` constructor instead of the esbuild resolver.