### PR TITLE
Introduce `injectStylesAs` config for html plugin

### DIFF
--- a/.changeset/plenty-yaks-heal.md
+++ b/.changeset/plenty-yaks-heal.md
@@ -1,0 +1,5 @@
+---
+"@chialab/esbuild-plugin-html": patch
+---
+
+Introduce `injectStylesAs` config.

--- a/docs/guide/esbuild-plugin-html.md
+++ b/docs/guide/esbuild-plugin-html.md
@@ -85,6 +85,15 @@ The target of the plain scripts build (`type="text/javascript"`).
 
 The target of the ES modules build (`type="module"`).
 
+#### `injectStylesAs`
+
+The method to inject styles in the document when imported in a JavaScript module.  
+It can be `link` or `script` (default).
+
+#### `minifyOptions`
+
+The options for the minification process. If the `htmlnano` module is installed, the plugin will minify the HTML output.
+
 ## How it works
 
 **Esbuild Plugin HTML** instructs esbuild to load a HTML file as entrypoint. It parses the HTML and runs esbuild on scripts, styles, assets and icons.
@@ -117,7 +126,7 @@ This will result in producing two bundles:
 
 ### Styles
 
-It supports both `<link rel="stylesheet">` and `<style>` nodes for styling.
+The plugins collects `<link rel="stylesheet">` entrypoints, `<style>` nodes and CSS imports in JavaScript modules.
 
 **Sample**
 

--- a/packages/esbuild-plugin-html/lib/collectAssets.js
+++ b/packages/esbuild-plugin-html/lib/collectAssets.js
@@ -27,7 +27,7 @@ export async function collectAsset($, element, attribute, options, helpers) {
 
 /**
  * Collect and bundle each node with a src reference.
- * @type {import('./index').Collector}
+ * @type {import('./index').Collector<{}>}
  */
 export async function collectAssets($, dom, options, helpers) {
     const builds = await Promise.all([

--- a/packages/esbuild-plugin-html/lib/collectIcons.js
+++ b/packages/esbuild-plugin-html/lib/collectIcons.js
@@ -119,7 +119,7 @@ export async function collectIcon($, element, icon, rel, shortcut, options, help
 
 /**
  * Collect and bundle apple icons.
- * @type {import('./index').Collector}
+ * @type {import('./index').Collector<{}>}
  */
 async function collectAppleIcons($, dom, options, helpers) {
     let remove = true;
@@ -173,7 +173,7 @@ async function collectAppleIcons($, dom, options, helpers) {
 
 /**
  * Collect and bundle favicons.
- * @type {import('./index').Collector}
+ * @type {import('./index').Collector<{}>}
  */
 export async function collectIcons($, dom, options, helpers) {
     const { resolve, load } = helpers;

--- a/packages/esbuild-plugin-html/lib/collectScreens.js
+++ b/packages/esbuild-plugin-html/lib/collectScreens.js
@@ -103,7 +103,7 @@ export async function collectScreen($, element, screen, options, helpers) {
 
 /**
  * Collect and bundle apple screens.
- * @type {import('./index').Collector}
+ * @type {import('./index').Collector<{}>}
  */
 export async function collectScreens($, dom, options, helpers) {
     const splashElement = dom.find('link[rel*="apple-touch-startup-image"]').last();

--- a/packages/esbuild-plugin-html/lib/collectStyles.js
+++ b/packages/esbuild-plugin-html/lib/collectStyles.js
@@ -3,7 +3,7 @@ import { isRelativeUrl } from '@chialab/node-resolve';
 
 /**
  * Collect and bundle each <link> reference.
- * @type {import('./index').Collector}
+ * @type {import('./index').Collector<{}>}
  */
 export async function collectStyles($, dom, options, helpers) {
     const elements = dom

--- a/packages/esbuild-plugin-html/lib/collectWebManifest.js
+++ b/packages/esbuild-plugin-html/lib/collectWebManifest.js
@@ -45,7 +45,7 @@ const MANIFEST_ICONS = [
 
 /**
  * Collect and bundle webmanifests.
- * @type {import('./index').Collector}
+ * @type {import('./index').Collector<{}>}
  */
 export async function collectWebManifest($, dom, options, helpers) {
     const htmlElement = dom.find('html');

--- a/packages/esbuild-plugin-html/test/test.spec.js
+++ b/packages/esbuild-plugin-html/test/test.spec.js
@@ -77,6 +77,68 @@ body {
 `);
     });
 
+    test('should bundle webapp with scripts injecting links', async () => {
+        const { outputFiles } = await esbuild.build({
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.iife.html', import.meta.url))],
+            sourceRoot: '/',
+            chunkNames: '[name]-[hash]',
+            outdir: 'out',
+            format: 'esm',
+            bundle: true,
+            write: false,
+            plugins: [
+                htmlPlugin({
+                    injectStylesAs: 'link',
+                }),
+            ],
+        });
+
+        const [index, js, css] = outputFiles;
+
+        expect(outputFiles).toHaveLength(3);
+
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.iife.html'));
+        expect(index.text).toBe(`<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="stylesheet" href="index-UMVLUHQU.css">
+</head>
+
+<body>
+    <script src="index-33TQGLB6.js" type="application/javascript"></script>
+</body>
+
+</html>`);
+
+        expect(js.path).endsWith(path.join(path.sep, 'out', 'index-33TQGLB6.js'));
+        expect(js.text).toBe(`"use strict";
+(() => {
+  // fixture/lib.js
+  var log = console.log.bind(console);
+
+  // fixture/index.js
+  window.addEventListener("load", () => {
+    log("test");
+  });
+})();
+`);
+
+        expect(css.path).endsWith(path.join(path.sep, 'out', 'index-UMVLUHQU.css'));
+        expect(css.text).toBe(`/* fixture/index.css */
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+`);
+    });
+
     test('should bundle webapp with scripts using public path', async () => {
         const { outputFiles } = await esbuild.build({
             absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),


### PR DESCRIPTION
This PR introduces a `injectStylesAs` configuration to set the inject behavior for CSS imports in JavaScript modules.

It should fix #172 