### PR TITLE
Correctly handle empty virtual modules

### DIFF
--- a/.changeset/pretty-experts-grin.md
+++ b/.changeset/pretty-experts-grin.md
@@ -1,0 +1,5 @@
+---
+'@chialab/esbuild-plugin-html': patch
+---
+
+Ignore empty `<script>` and `<style>` elements.

--- a/.changeset/twelve-dragons-cover.md
+++ b/.changeset/twelve-dragons-cover.md
@@ -1,0 +1,5 @@
+---
+'@chialab/esbuild-rna': patch
+---
+
+Correctly handle empty (`contents = ''`) virtual modules.

--- a/packages/esbuild-plugin-html/lib/collectScripts.js
+++ b/packages/esbuild-plugin-html/lib/collectScripts.js
@@ -42,6 +42,10 @@ async function innerCollect($, dom, elements, target, format, type, attrs = {}, 
                 builds.set(element, resolvedFile.path);
                 entrypoints.set(resolvedFile.path, element);
             } else {
+                const contents = $(element).html() || '';
+                if (!contents) {
+                    return;
+                }
                 const entryPoint = path.join(options.sourceDir, helpers.createEntry('js'));
                 builds.set(element, {
                     path: entryPoint,

--- a/packages/esbuild-plugin-html/lib/collectStyles.js
+++ b/packages/esbuild-plugin-html/lib/collectStyles.js
@@ -37,6 +37,10 @@ export async function collectStyles($, dom, options, helpers) {
                 builds.set(element, resolvedFile.path);
                 entrypoints.set(resolvedFile.path, element);
             } else {
+                const contents = $(element).html() || '';
+                if (!contents) {
+                    return;
+                }
                 const entryPoint = path.join(options.sourceDir, helpers.createEntry('css'));
                 builds.set(element, {
                     path: entryPoint,

--- a/packages/esbuild-plugin-html/test/fixture/index.css.html
+++ b/packages/esbuild-plugin-html/test/fixture/index.css.html
@@ -11,6 +11,8 @@
             color: red;
         }
     </style>
+    <!-- Empty style tag -->
+    <style></style>
 </head>
 <body>
 

--- a/packages/esbuild-plugin-html/test/test.spec.js
+++ b/packages/esbuild-plugin-html/test/test.spec.js
@@ -714,6 +714,8 @@ body {
     <style>
         @import '1-EKADEBHI.css'
     </style>
+    <!-- Empty style tag -->
+    <style></style>
 </head>
 
 <body>
@@ -770,6 +772,8 @@ body {
     <style>
         @import '/public/1-VXBR4AUQ.css'
     </style>
+    <!-- Empty style tag -->
+    <style></style>
 </head>
 
 <body>

--- a/packages/esbuild-rna/lib/Build.js
+++ b/packages/esbuild-rna/lib/Build.js
@@ -666,7 +666,7 @@ export class Build {
             resolveDir = args.resolveDir;
         } else {
             const loadResult = await this.load(args);
-            if (!loadResult || !loadResult.contents) {
+            if (!loadResult || loadResult.contents == null) {
                 return;
             }
 
@@ -1025,7 +1025,7 @@ export class Build {
                 with: {},
             });
 
-            if (result && result.contents) {
+            if (result && result.contents != null) {
                 buffer = Buffer.from(result.contents);
             } else {
                 buffer = await readFile(source);
@@ -1119,7 +1119,7 @@ export class Build {
             value: true,
         });
 
-        if (options.contents) {
+        if (options.contents != null) {
             delete config.entryPoints;
             config.stdin = {
                 sourcefile: options.path,
@@ -1207,7 +1207,7 @@ export class Build {
                     if (typeof entryPoint !== 'object') {
                         return;
                     }
-                    if (entryPoint.contents) {
+                    if (entryPoint.contents != null) {
                         build.addVirtualModule(entryPoint);
                     }
                 });


### PR DESCRIPTION
Empty virtual modules are now correctly resolved.
Also, add a check to ignore empty `<script>` and `<style>` in html plugin.

Fixes #190