### PR TITLE
Optional icon generator by `generateIcons` option

### DIFF
--- a/.changeset/safari-unstaffed-strive.md
+++ b/.changeset/safari-unstaffed-strive.md
@@ -1,0 +1,5 @@
+---
+"@chialab/esbuild-plugin-html": patch
+---
+
+Introduce `generateIcons` config.

--- a/docs/guide/esbuild-plugin-html.md
+++ b/docs/guide/esbuild-plugin-html.md
@@ -94,6 +94,11 @@ It can be `link` or `script` (default).
 
 The options for the minification process. If the `htmlnano` module is installed, the plugin will minify the HTML output.
 
+#### `generateIcons`
+
+Enable or disable the generation of the icons.
+It can be `true` (default) or `false`.
+
 ## How it works
 
 **Esbuild Plugin HTML** instructs esbuild to load a HTML file as entrypoint. It parses the HTML and runs esbuild on scripts, styles, assets and icons.
@@ -171,6 +176,8 @@ This will result in:
 ### Icons
 
 Manually generate favicons can be a pain. This plugin detects a `<link rel="icon">` node and uses its reference to generate icons and launch screens for (almost) every browser.
+
+This step can be disabled by setting the option `generateIcons` to `false`.
 
 **Sample**
 

--- a/packages/esbuild-plugin-html/lib/collectIcons.js
+++ b/packages/esbuild-plugin-html/lib/collectIcons.js
@@ -89,7 +89,7 @@ async function generateAppleIcons(image, icons) {
  * @param {Icon} icon The generated icon file.
  * @param {string} rel Rel attribute.
  * @param {boolean} shortcut Should include shortcut.
- * @param {import('./index.js').BuildOptions} options Build options.
+ * @param {import('./index.js').CollectOptions<{ generateIcons: boolean }>} options Build options.
  * @param {import('./index.js').Helpers} helpers Helpers.
  * @returns {Promise<import('@chialab/esbuild-rna').OnTransformResult>} Plain build.
  */
@@ -173,10 +173,14 @@ async function collectAppleIcons($, dom, options, helpers) {
 
 /**
  * Collect and bundle favicons.
- * @type {import('./index').Collector<{}>}
+ * @type {import('./index').Collector<{ generateIcons: boolean }>}
  */
 export async function collectIcons($, dom, options, helpers) {
     const { resolve, load } = helpers;
+
+    if (!options.generateIcons) {
+        return [];
+    }
 
     const iconElement = dom.find(ICON_SELECTORS.join(',')).last();
     if (!iconElement.length) {

--- a/packages/esbuild-plugin-html/lib/index.js
+++ b/packages/esbuild-plugin-html/lib/index.js
@@ -22,6 +22,7 @@ const loadHtml = /** @type {typeof cheerio.load} */ (cheerio.load || cheerio.def
  * @property {string} [chunkNames]
  * @property {string} [assetNames]
  * @property {'link' | 'script'} [injectStylesAs]
+ * @property {boolean} [generateIcons]
  * @property {import('htmlnano').HtmlnanoOptions} [minifyOptions]
  */
 
@@ -66,6 +67,7 @@ export default function ({
     modulesTarget = 'es2020',
     minifyOptions = {},
     injectStylesAs = 'script',
+    generateIcons = true,
 } = {}) {
     /**
      * @type {import('esbuild').Plugin}
@@ -261,7 +263,17 @@ export default function ({
 
                 const results = await collectWebManifest($, root, collectOptions, helpers);
                 results.push(...(await collectScreens($, root, collectOptions, helpers)));
-                results.push(...(await collectIcons($, root, collectOptions, helpers)));
+                results.push(
+                    ...(await collectIcons(
+                        $,
+                        root,
+                        {
+                            ...collectOptions,
+                            generateIcons,
+                        },
+                        helpers
+                    ))
+                );
                 results.push(...(await collectAssets($, root, collectOptions, helpers)));
                 results.push(...(await collectStyles($, root, collectOptions, helpers)));
                 results.push(

--- a/packages/esbuild-plugin-html/test/test.spec.js
+++ b/packages/esbuild-plugin-html/test/test.spec.js
@@ -967,6 +967,47 @@ html {
         expect(icons[3].contents.byteLength).toBe(6366);
     });
 
+    test('should not generate favicons', async () => {
+        const { outputFiles } = await esbuild.build({
+            absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),
+            entryPoints: [fileURLToPath(new URL('fixture/index.icons.html', import.meta.url))],
+            sourceRoot: '/',
+            assetNames: 'icons/[name]',
+            outdir: 'out',
+            format: 'esm',
+            bundle: true,
+            write: false,
+            plugins: [
+                htmlPlugin({
+                    generateIcons: false,
+                }),
+            ],
+        });
+
+        const [index, ...icons] = outputFiles;
+
+        expect(outputFiles).toHaveLength(1);
+
+        expect(index.path).endsWith(path.join(path.sep, 'out', 'index.icons.html'));
+        expect(index.text).toBe(`<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="shortcut icon" href="img/icon.png" type="image/png">
+</head>
+
+<body>
+</body>
+
+</html>`);
+
+        expect(icons).toHaveLength(0);
+    });
+
     test('should bundle webapp with svg favicon', async () => {
         const { outputFiles } = await esbuild.build({
             absWorkingDir: fileURLToPath(new URL('.', import.meta.url)),


### PR DESCRIPTION
The reason for this commit is that I use another custom generator for favicons (it generates PNGs from an SVG with a custom filename). Because of this, when esbuild-plugin-html tries to load the favicons referred URLs, it fails with the following error:

```
✘ [ERROR] Failed to resolve icon path: assets/icon-dark-196x196.png [plugin html]

✘ [ERROR] Failed to resolve icon path: assets/icon-dark-196x196.png [plugin html]

[build][resources][manifests]: 25.672ms
Error: Build failed with 2 errors:
error: Failed to resolve icon path: assets/icon-dark-196x196.png
error: Failed to resolve icon path: assets/icon-dark-196x196.png
    at failureErrorWithLog (node_modules/esbuild/lib/main.js:1472:15)
    at node_modules/esbuild/lib/main.js:945:25
    at node_modules/esbuild/lib/main.js:1353:9
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  errors: [Getter/Setter],
  warnings: [Getter/Setter]
}
[build]: 30.824ms
[build][resources][assets]: 38.637ms
```

Therefore, to ignore these errors, I added the build option `generateIcons` as a flag for the `collectIcons`.

The default value is `true`, so its behavior will be the same as always.

I added a test for `generateIcons` set to `false`.