### PR TITLE
Update expected browser title for Vitest

### DIFF
--- a/packages/vitest-provider-browserstack/lib/index.js
+++ b/packages/vitest-provider-browserstack/lib/index.js
@@ -191,7 +191,7 @@ export default class BrowserStackProvider extends webdriverio {
         await browser.navigateTo(url);
 
         const title = await browser.getTitle();
-        if (title !== 'Vitest Browser Runner') {
+        if (title !== 'Vitest') {
             throw new Error('Failed to open url');
         }
     };


### PR DESCRIPTION
Not sure when the title changed in vitest, but this will make it work with at least vitest 3.1.2. 

Are there any plans to release v0.19 soon?