### PR TITLE
fix(estransform): Updated oxc-parser to 0.114.0

### DIFF
--- a/.changeset/upgrade-oxc-parser.md
+++ b/.changeset/upgrade-oxc-parser.md
@@ -1,0 +1,12 @@
+---
+"@chialab/estransform": minor
+"@chialab/cem-analyzer": patch
+"@chialab/cjs-to-esm": patch
+"@chialab/esbuild-plugin-meta-url": patch
+"@chialab/esbuild-plugin-require-resolve": patch
+"@chialab/esbuild-plugin-unwebpack": patch
+"@chialab/esbuild-plugin-worker": patch
+"@chialab/vite-plugin-worker-proxy": patch
+---
+
+Update `oxc-parser` to `^0.114.0` and migrate AST consumers to the ESTree-conformant node shape.

--- a/packages/cem-analyzer/lib/creators/create-function.js
+++ b/packages/cem-analyzer/lib/creators/create-function.js
@@ -1,5 +1,5 @@
 /**
- * @import { ArrowFunctionExpression, Function as IFunction, TSTypeAnnotation } from '@oxc-project/types'
+ * @import { ArrowFunctionExpression, Function as OxcFunction, TSTypeAnnotation } from '@oxc-project/types'
  * @import { Block } from 'comment-parser'
  * @import { FunctionDeclaration, Parameter } from 'custom-elements-manifest'
  * @import { Context } from '../generate'
@@ -8,7 +8,7 @@ import { decorateWithJSDoc, literalToType } from '../utils.js';
 
 /**
  * @param {Context} context
- * @param {ArrowFunctionExpression | IFunction} node
+ * @param {ArrowFunctionExpression | OxcFunction} node
  * @param {Block[]} [jsdoc=context.parseJSDoc(node)]
  * @returns {FunctionDeclaration}
  */

--- a/packages/cem-analyzer/lib/frameworks/dna/property-decorator.js
+++ b/packages/cem-analyzer/lib/frameworks/dna/property-decorator.js
@@ -1,5 +1,5 @@
 /**
- * @import { BooleanLiteral, CallExpression, ObjectProperty, StringLiteral } from '@oxc-project/types'
+ * @import { CallExpression, ObjectProperty } from '@oxc-project/types'
  * @import { Attribute, CustomElementDeclaration, CustomElementField } from 'custom-elements-manifest'
  * @import { Plugin } from '../../generate.js'
  */
@@ -77,7 +77,7 @@ export function propertyDecoratorPlugin() {
                             prop.value.type === 'Literal'
                     )
                 );
-                if (/** @type {StringLiteral | BooleanLiteral | undefined} */ (propertyAttr?.value)?.value === false) {
+                if (propertyAttr?.value.type === 'Literal' && propertyAttr.value.value === false) {
                     return;
                 }
 

--- a/packages/cem-analyzer/lib/frameworks/dna/static-properties.js
+++ b/packages/cem-analyzer/lib/frameworks/dna/static-properties.js
@@ -1,5 +1,5 @@
 /**
- * @import { BooleanLiteral, Function as IFunction, ObjectProperty, StringLiteral } from '@oxc-project/types'
+ * @import { Function as OxcFunction, ObjectProperty } from '@oxc-project/types'
  * @import { Attribute, CustomElementDeclaration, CustomElementField } from 'custom-elements-manifest'
  * @import { Plugin } from '../../generate.js'
  */
@@ -39,9 +39,9 @@ export function staticPropertiesPlugin() {
                         ? member.value?.type === 'ObjectExpression'
                             ? member.value
                             : undefined
-                        : /** @type {IFunction} */ (member.value).body?.body?.find((n) => n.type === 'ReturnStatement')
+                        : /** @type {OxcFunction} */ (member.value).body?.body?.find((n) => n.type === 'ReturnStatement')
                                 ?.argument?.type === 'ObjectExpression'
-                          ? /** @type {IFunction} */ (member.value).body?.body?.find(
+                          ? /** @type {OxcFunction} */ (member.value).body?.body?.find(
                                 (n) => n.type === 'ReturnStatement'
                             )?.argument
                           : undefined;
@@ -122,7 +122,7 @@ export function staticPropertiesPlugin() {
                     );
                     if (
                         !propertyAttr ||
-                        /** @type {StringLiteral | BooleanLiteral | undefined} */ (propertyAttr?.value)?.value !== false
+                        !(propertyAttr.value.type === 'Literal' && propertyAttr.value.value === false)
                     ) {
                         /** @type {Attribute} */
                         const attribute = {

--- a/packages/cem-analyzer/lib/frameworks/lit/property-decorator.js
+++ b/packages/cem-analyzer/lib/frameworks/lit/property-decorator.js
@@ -1,5 +1,5 @@
 /**
- * @import { BooleanLiteral, CallExpression, ObjectProperty, StringLiteral } from '@oxc-project/types'
+ * @import { CallExpression, ObjectProperty } from '@oxc-project/types'
  * @import { Attribute, CustomElementDeclaration, CustomElementField } from 'custom-elements-manifest'
  * @import { Plugin } from '../../generate.js'
  */
@@ -65,7 +65,7 @@ export function propertyDecoratorPlugin() {
                             prop.value.type === 'Literal'
                     )
                 );
-                if (/** @type {StringLiteral | BooleanLiteral | undefined} */ (propertyAttr?.value)?.value === false) {
+                if (propertyAttr?.value.type === 'Literal' && propertyAttr.value.value === false) {
                     return;
                 }
 

--- a/packages/cem-analyzer/lib/frameworks/lit/static-properties.js
+++ b/packages/cem-analyzer/lib/frameworks/lit/static-properties.js
@@ -1,5 +1,5 @@
 /**
- * @import { BooleanLiteral, Function as IFunction, ObjectProperty, StringLiteral } from '@oxc-project/types'
+ * @import { Function as OxcFunction, ObjectProperty } from '@oxc-project/types'
  * @import { Attribute, CustomElementDeclaration, CustomElementField } from 'custom-elements-manifest'
  * @import { Plugin } from '../../generate.js'
  */
@@ -42,9 +42,9 @@ export function staticPropertiesPlugin() {
                         ? member.value?.type === 'ObjectExpression'
                             ? member.value
                             : undefined
-                        : /** @type {IFunction} */ (member.value).body?.body?.find((n) => n.type === 'ReturnStatement')
+                        : /** @type {OxcFunction} */ (member.value).body?.body?.find((n) => n.type === 'ReturnStatement')
                                 ?.argument?.type === 'ObjectExpression'
-                          ? /** @type {IFunction} */ (member.value).body?.body?.find(
+                          ? /** @type {OxcFunction} */ (member.value).body?.body?.find(
                                 (n) => n.type === 'ReturnStatement'
                             )?.argument
                           : undefined;
@@ -125,7 +125,7 @@ export function staticPropertiesPlugin() {
                     );
                     if (
                         !propertyAttr ||
-                        /** @type {StringLiteral | BooleanLiteral | undefined} */ (propertyAttr?.value)?.value !== false
+                        !(propertyAttr.value.type === 'Literal' && propertyAttr.value.value === false)
                     ) {
                         /** @type {Attribute} */
                         const attribute = {

--- a/packages/cjs-to-esm/lib/index.js
+++ b/packages/cjs-to-esm/lib/index.js
@@ -221,7 +221,7 @@ export async function transform(
                 }
 
                 const specifier = node.arguments[0];
-                if (specifier.type === 'StringLiteral') {
+                if (specifier.type === 'Literal' && typeof specifier.value === 'string') {
                     callExpressions.push(node);
                 }
             },

--- a/packages/esbuild-plugin-meta-url/lib/index.js
+++ b/packages/esbuild-plugin-meta-url/lib/index.js
@@ -82,7 +82,12 @@ export default function ({ emit = true } = {}) {
                 const symbols = {};
                 walk(ast, {
                     VariableDeclarator(node) {
-                        if (node.id.type === 'Identifier' && node.init && node.init.type === 'StringLiteral') {
+                        if (
+                            node.id.type === 'Identifier' &&
+                            node.init &&
+                            node.init.type === 'Literal' &&
+                            typeof node.init.value === 'string'
+                        ) {
                             symbols[node.id.name] = node.init.value;
                         }
                     },
@@ -92,7 +97,7 @@ export default function ({ emit = true } = {}) {
                     async NewExpression(node) {
                         const callee = node.callee;
                         if (callee.type !== 'Identifier' || callee.name !== 'URL') {
-                            if (callee.type !== 'StaticMemberExpression') {
+                            if (callee.type !== 'MemberExpression' || callee.computed) {
                                 return;
                             }
                             if (
@@ -110,7 +115,8 @@ export default function ({ emit = true } = {}) {
                         const originArgument = node.arguments[1];
                         if (
                             !originArgument ||
-                            originArgument.type !== 'StaticMemberExpression' ||
+                            originArgument.type !== 'MemberExpression' ||
+                            originArgument.computed ||
                             originArgument.object.type !== 'MetaProperty' ||
                             originArgument.object.meta.name !== 'import' ||
                             originArgument.object.property.name !== 'meta' ||
@@ -121,7 +127,7 @@ export default function ({ emit = true } = {}) {
                         }
 
                         const value =
-                            argument.type === 'StringLiteral'
+                            argument.type === 'Literal' && typeof argument.value === 'string'
                                 ? argument.value
                                 : argument.type === 'Identifier'
                                   ? symbols[argument.name]

--- a/packages/esbuild-plugin-require-resolve/lib/index.js
+++ b/packages/esbuild-plugin-require-resolve/lib/index.js
@@ -26,7 +26,8 @@ export default function () {
                 await walk(ast, {
                     async CallExpression(node) {
                         if (
-                            node.callee.type !== 'StaticMemberExpression' ||
+                            node.callee.type !== 'MemberExpression' ||
+                            node.callee.computed ||
                             node.callee.object.type !== 'Identifier' ||
                             node.callee.object.name !== 'require' ||
                             node.callee.property.type !== 'Identifier' ||
@@ -36,7 +37,7 @@ export default function () {
                         }
 
                         const argument = node.arguments[0];
-                        if (argument.type !== 'StringLiteral') {
+                        if (argument.type !== 'Literal' || typeof argument.value !== 'string') {
                             return;
                         }
 

--- a/packages/esbuild-plugin-unwebpack/lib/index.js
+++ b/packages/esbuild-plugin-unwebpack/lib/index.js
@@ -105,7 +105,8 @@ export default function () {
                     IfStatement(node) {
                         // if (module.hot) {
                         if (
-                            node.test.type === 'StaticMemberExpression' &&
+                            node.test.type === 'MemberExpression' &&
+                            !node.test.computed &&
                             node.test.object.type === 'Identifier' &&
                             node.test.object.name === 'module' &&
                             node.test.property.type === 'Identifier' &&
@@ -117,7 +118,8 @@ export default function () {
 
                         // if (import.meta.webpackHot) {
                         if (
-                            node.test.type === 'StaticMemberExpression' &&
+                            node.test.type === 'MemberExpression' &&
+                            !node.test.computed &&
                             node.test.object.type === 'MetaProperty' &&
                             node.test.object.meta.type === 'Identifier' &&
                             node.test.object.meta.name === 'import' &&
@@ -136,7 +138,8 @@ export default function () {
                             node.test.operator === '&&' &&
                             node.test.left.type === 'Identifier' &&
                             node.test.left.name === 'module' &&
-                            node.test.right.type === 'StaticMemberExpression' &&
+                            node.test.right.type === 'MemberExpression' &&
+                            !node.test.right.computed &&
                             node.test.right.object.type === 'Identifier' &&
                             node.test.right.object.name === 'module' &&
                             node.test.right.property.type === 'Identifier' &&
@@ -154,13 +157,16 @@ export default function () {
                             node.test.left.operator === '&&' &&
                             node.test.left.left.type === 'Identifier' &&
                             node.test.left.left.name === 'module' &&
-                            node.test.left.right.type === 'StaticMemberExpression' &&
+                            node.test.left.right.type === 'MemberExpression' &&
+                            !node.test.left.right.computed &&
                             node.test.left.right.object.type === 'Identifier' &&
                             node.test.left.right.object.name === 'module' &&
                             node.test.left.right.property.type === 'Identifier' &&
                             node.test.left.right.property.name === 'hot' &&
-                            node.test.right.type === 'StaticMemberExpression' &&
-                            node.test.right.object.type === 'StaticMemberExpression' &&
+                            node.test.right.type === 'MemberExpression' &&
+                            !node.test.right.computed &&
+                            node.test.right.object.type === 'MemberExpression' &&
+                            !node.test.right.object.computed &&
                             node.test.right.object.object.type === 'Identifier' &&
                             node.test.right.object.object.name === 'module' &&
                             node.test.right.object.property.type === 'Identifier' &&

--- a/packages/esbuild-plugin-worker/lib/index.js
+++ b/packages/esbuild-plugin-worker/lib/index.js
@@ -85,7 +85,12 @@ export default function ({ constructors = ['Worker', 'SharedWorker'], proxy = fa
                         classDeclarations.push(node.id.name);
                     },
                     VariableDeclarator(node) {
-                        if (node.id.type === 'Identifier' && node.init && node.init.type === 'StringLiteral') {
+                        if (
+                            node.id.type === 'Identifier' &&
+                            node.init &&
+                            node.init.type === 'Literal' &&
+                            typeof node.init.value === 'string'
+                        ) {
                             symbols[node.id.name] = node.init.value;
                         }
                     },
@@ -95,7 +100,7 @@ export default function ({ constructors = ['Worker', 'SharedWorker'], proxy = fa
                     async NewExpression(node) {
                         const callee = node.callee;
                         if (callee.type !== 'Identifier' || !constructors.includes(callee.name)) {
-                            if (callee.type !== 'StaticMemberExpression') {
+                            if (callee.type !== 'MemberExpression' || callee.computed) {
                                 return;
                             }
                             if (
@@ -129,10 +134,11 @@ export default function ({ constructors = ['Worker', 'SharedWorker'], proxy = fa
                         if (options && options.type === 'ObjectExpression') {
                             for (const property of options.properties) {
                                 if (
-                                    property.type === 'ObjectProperty' &&
+                                    property.type === 'Property' &&
                                     property.key.type === 'Identifier' &&
                                     property.key.name === 'type' &&
-                                    property.value.type === 'StringLiteral'
+                                    property.value.type === 'Literal' &&
+                                    typeof property.value.value === 'string'
                                 ) {
                                     transformOptions.format = 'esm';
                                     transformOptions.external = undefined;
@@ -147,7 +153,7 @@ export default function ({ constructors = ['Worker', 'SharedWorker'], proxy = fa
                             argument.callee.type !== 'Identifier' ||
                             argument.callee.name !== 'URL'
                         ) {
-                            const isStringLiteral = argument.type === 'StringLiteral';
+                            const isStringLiteral = argument.type === 'Literal' && typeof argument.value === 'string';
                             const isIdentifier = argument.type === 'Identifier';
                             if ((isStringLiteral || isIdentifier) && proxy) {
                                 const arg = helpers.substring(argument.start, argument.end);
@@ -164,7 +170,8 @@ export default function ({ constructors = ['Worker', 'SharedWorker'], proxy = fa
                         const originArgument = argument.arguments[1];
                         if (
                             !originArgument ||
-                            originArgument.type !== 'StaticMemberExpression' ||
+                            originArgument.type !== 'MemberExpression' ||
+                            originArgument.computed ||
                             originArgument.object.type !== 'MetaProperty' ||
                             originArgument.object.meta.name !== 'import' ||
                             originArgument.object.property.name !== 'meta' ||
@@ -174,7 +181,7 @@ export default function ({ constructors = ['Worker', 'SharedWorker'], proxy = fa
                             return;
                         }
 
-                        const isStringLiteral = reference.type === 'StringLiteral';
+                        const isStringLiteral = reference.type === 'Literal' && typeof reference.value === 'string';
                         const isIdentifier = reference.type === 'Identifier';
                         if (!isStringLiteral && !isIdentifier && !proxy) {
                             return;

--- a/packages/estransform/lib/parser.js
+++ b/packages/estransform/lib/parser.js
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { MagicString } from '@napi-rs/magic-string';
-import { parseAsync } from 'oxc-parser';
+import { parse as oxcParse } from 'oxc-parser';
 import { inlineSourcemap, loadSourcemap, mergeSourcemaps, removeInlineSourcemap } from './sourcemaps.js';
 
 /**
@@ -56,8 +56,8 @@ export async function parse(inputCode, filePath) {
     const code = removeInlineSourcemap(inputCode);
     const buffer = Buffer.from(code);
     const magicCode = new MagicString(code);
-    const result = await parseAsync(code, { sourceType: 'module', sourceFilename: filePath });
-    const ast = JSON.parse(result.program);
+    const result = await oxcParse(filePath ?? '', code, { sourceType: 'module' });
+    const ast = result.program;
 
     let changed = false;
 

--- a/packages/estransform/package.json
+++ b/packages/estransform/package.json
@@ -39,7 +39,7 @@
     "@parcel/source-map": "^2.0.0",
     "cjs-module-lexer": "^1.2.2",
     "es-module-lexer": "^1.0.0",
-    "oxc-parser": "^0.8.0"
+    "oxc-parser": "^0.114.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/vite-plugin-worker-proxy/lib/index.js
+++ b/packages/vite-plugin-worker-proxy/lib/index.js
@@ -40,7 +40,7 @@ export default function workerProxy({ constructors = ['Worker', 'SharedWorker'] 
                 async NewExpression(node) {
                     const callee = node.callee;
                     if (callee.type !== 'Identifier' || !constructors.includes(callee.name)) {
-                        if (callee.type !== 'StaticMemberExpression') {
+                        if (callee.type !== 'MemberExpression' || callee.computed) {
                             return;
                         }
                         if (
@@ -66,10 +66,11 @@ export default function workerProxy({ constructors = ['Worker', 'SharedWorker'] 
                     if (options && options.type === 'ObjectExpression') {
                         for (const property of options.properties) {
                             if (
-                                property.type === 'ObjectProperty' &&
+                                property.type === 'Property' &&
                                 property.key.type === 'Identifier' &&
                                 property.key.name === 'type' &&
-                                property.value.type === 'StringLiteral'
+                                property.value.type === 'Literal' &&
+                                typeof property.value.value === 'string'
                             ) {
                                 type = property.value.value;
                                 break;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,7 +1745,7 @@ __metadata:
     "@parcel/source-map": ^2.0.0
     cjs-module-lexer: ^1.2.2
     es-module-lexer: ^1.0.0
-    oxc-parser: ^0.8.0
+    oxc-parser: ^0.114.0
     typescript: ^5.0.0
   languageName: unknown
   linkType: soft
@@ -3521,23 +3521,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-darwin-arm64@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@oxc-parser/binding-darwin-arm64@npm:0.8.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@oxc-parser/binding-darwin-x64@npm:0.114.0":
   version: 0.114.0
   resolution: "@oxc-parser/binding-darwin-x64@npm:0.114.0"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oxc-parser/binding-darwin-x64@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@oxc-parser/binding-darwin-x64@npm:0.8.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -3570,23 +3556,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-arm64-gnu@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@oxc-parser/binding-linux-arm64-gnu@npm:0.8.0"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@oxc-parser/binding-linux-arm64-musl@npm:0.114.0":
   version: 0.114.0
   resolution: "@oxc-parser/binding-linux-arm64-musl@npm:0.114.0"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@oxc-parser/binding-linux-arm64-musl@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@oxc-parser/binding-linux-arm64-musl@npm:0.8.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -3626,23 +3598,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-linux-x64-gnu@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@oxc-parser/binding-linux-x64-gnu@npm:0.8.0"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@oxc-parser/binding-linux-x64-musl@npm:0.114.0":
   version: 0.114.0
   resolution: "@oxc-parser/binding-linux-x64-musl@npm:0.114.0"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@oxc-parser/binding-linux-x64-musl@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@oxc-parser/binding-linux-x64-musl@npm:0.8.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -3670,13 +3628,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-parser/binding-win32-arm64-msvc@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@oxc-parser/binding-win32-arm64-msvc@npm:0.8.0"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@oxc-parser/binding-win32-ia32-msvc@npm:0.114.0":
   version: 0.114.0
   resolution: "@oxc-parser/binding-win32-ia32-msvc@npm:0.114.0"
@@ -3687,13 +3638,6 @@ __metadata:
 "@oxc-parser/binding-win32-x64-msvc@npm:0.114.0":
   version: 0.114.0
   resolution: "@oxc-parser/binding-win32-x64-msvc@npm:0.114.0"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@oxc-parser/binding-win32-x64-msvc@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@oxc-parser/binding-win32-x64-msvc@npm:0.8.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -10536,39 +10480,6 @@ __metadata:
     "@oxc-parser/binding-win32-x64-msvc":
       optional: true
   checksum: 6c8acdd28a4a1fe98d8330d42d6b9bc7959a5f74499364223581941955322f7bce5445f44e6ad8b6c09d46df4cdd331a0053028584e9081fda3010b6512b3d73
-  languageName: node
-  linkType: hard
-
-"oxc-parser@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "oxc-parser@npm:0.8.0"
-  dependencies:
-    "@oxc-parser/binding-darwin-arm64": 0.8.0
-    "@oxc-parser/binding-darwin-x64": 0.8.0
-    "@oxc-parser/binding-linux-arm64-gnu": 0.8.0
-    "@oxc-parser/binding-linux-arm64-musl": 0.8.0
-    "@oxc-parser/binding-linux-x64-gnu": 0.8.0
-    "@oxc-parser/binding-linux-x64-musl": 0.8.0
-    "@oxc-parser/binding-win32-arm64-msvc": 0.8.0
-    "@oxc-parser/binding-win32-x64-msvc": 0.8.0
-  dependenciesMeta:
-    "@oxc-parser/binding-darwin-arm64":
-      optional: true
-    "@oxc-parser/binding-darwin-x64":
-      optional: true
-    "@oxc-parser/binding-linux-arm64-gnu":
-      optional: true
-    "@oxc-parser/binding-linux-arm64-musl":
-      optional: true
-    "@oxc-parser/binding-linux-x64-gnu":
-      optional: true
-    "@oxc-parser/binding-linux-x64-musl":
-      optional: true
-    "@oxc-parser/binding-win32-arm64-msvc":
-      optional: true
-    "@oxc-parser/binding-win32-x64-msvc":
-      optional: true
-  checksum: e60e5817e66b1e8020dcfdc45c7e730882e477798fc067e98aa7d473d887334e62876c85824769d61b6bf5f07068d34001081dd61c7f152db9a8eccf32e054fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

Upgrades `oxc-parser` from `^0.8.0` to `^0.114.0` in `@chialab/estransform` and adapts all consumers to the new API surface and AST shape. Mainly because we were dealing with a small bug in `oxc-parser@<=0.9.0`:

```
 ERRR  Error building federation artefacts
 ERRR  Cannot find module '@oxc-parser/binding-win32-x64-msvc'
Require stack:
- <repo_path>\node_modules\oxc-parser\index.js
```

However installing >0.10.0 of oxc-parser _seems_ to fix the issue. But while we're at it, we might as well bring it to the same version as `cem-analyzer`. Therefore the PR is a bit bigger than usual. 

  ## Changes

  - **`estransform`**: switches from the removed `parseAsync(code, opts)` to `parse(filename, source, opts)`. The returned `program` is now a parsed
  object, so the local `JSON.parse(result.program)` is dropped.
  - **AST migration**: `oxc-parser` now emits an ESTree-conformant AST by default. Updated node-type checks across `cem-analyzer`, `cjs-to-esm`,
  `esbuild-plugin-meta-url`, `esbuild-plugin-require-resolve`, `esbuild-plugin-unwebpack`, `esbuild-plugin-worker`, and `vite-plugin-worker-proxy`:
    - `StringLiteral` / `BooleanLiteral` → `Literal` + a `typeof value` / `value === false` check
    - `StaticMemberExpression` → `MemberExpression` + `!computed`
    - `ObjectProperty` → `Property`
  - JSDoc `@type {ObjectProperty | undefined}` casts on `.find(...)` results in `cem-analyzer` are preserved so `yarn types` stays clean (TS doesn't
  narrow `find`'s return type from a chained predicate).

## Quick overview of the oxc-parser changes between 0.8.0 and 0.114.0:


### Shift to ESTree Compatibility
The most significant change is the transition from a custom internal AST format to the industry-standard **ESTree**.
- **v0.8.0:** Used specialized nodes (e.g., `BindingIdentifier`, `IdentifierReference`).
- **v0.114.0:** Defaults to standard `Identifier` nodes, enabling direct compatibility with ESLint, Prettier, and other ecosystem tools.
- **Impact:** Existing AST traversal logic from 0.8.x will require updates to match ESTree node names.

### "Fast Mode" & Semantic Analysis
Oxc now separates syntax parsing from semantic validation to maximize performance.
- **Lazy Semantics:** The parser defaults to "Fast Mode," which ignores semantic errors (like duplicate variable declarations) unless `showSemanticErrors: true` is enabled.
- **Performance:** This allows Oxc to function as a pure, high-speed parser for tools that do not require full scope resolution.

### Integrated ESM Metadata
The parser now extracts module information during the parsing phase, returning it alongside the AST.
- **Module Record:** Provides a structured list of imports and exports without requiring a separate AST walk.
- **Use Case:** Simplifies the development of bundlers and dependency graph generators.

### Granular Parser Options
The API has been expanded to support diverse use cases through new configuration flags:
- **`astType`:** Allows toggling between standard JavaScript (`js`) and TypeScript (`ts`) AST formats (specifically `@typescript-eslint/typescript-estree`).
- **`preserveParens`:** Optional preservation of `ParenthesizedExpression` nodes.
- **TS Compatibility:** Full support for TypeScript 5.x features, including `using` declarations and Stage 3 Decorators.

### Technical Comparison Table

| Feature | v0.8.0 | v0.114.0 |
| :--- | :--- | :--- |
| **AST Format** | Custom Oxc | **ESTree (Standard)** |
| **Default Mode** | Semantic Check On | **Fast Mode (Syntax Only)** |
| **TS Support** | Experimental | **Production-ready / TS 5.x** |
| **ESM Extraction** | Manual AST Walk | **Automatic `module_record`** |
| **Decorators** | Legacy / Limited | **Stage 3 Support** |
  
  Thanks in advance for the review